### PR TITLE
neon: stride-128 prefix-sum merge kernels (merge_vec_vec / cst_vec / vec_cst)

### DIFF
--- a/bench/bench_prim.c
+++ b/bench/bench_prim.c
@@ -573,6 +573,291 @@ static inline void merge_neon_unroll8(const uint8_t *bm, int K,
 static void simd_merge_vec_vec_unroll8 (const ctx_t *c){
     merge_neon_unroll8(c->bm, c->n, c->merge_left, c->merge_right, c->out);
 }
+
+/* ---- 128-bit bitmap load + multiply-prefix-sum cursor decoupling ----
+ *
+ * Per outer iter (128 outputs):
+ *   - ONE vld1q_u8 of 16 bitmap bytes; ONE vcntq_u8 for all 16 popcounts.
+ *   - bitmap + popcount each spilled to 2x u64 GPRs (low/high 8 bytes), so
+ *     m0/m1/nr0 per block become ubfx (register bitfield extract) instead
+ *     of per-byte memory loads + the dependent expand_popcnt[] load.
+ *   - vpaddlq_u8 folds adjacent byte-popcounts into 8 per-16-elem-block
+ *     right-counts (nr0+nr1); reinterpreted as 2x u64 (4x u16 lanes each),
+ *     each multiplied by 0x0001000100010001 to get inclusive prefix sums
+ *     in the 16-bit lanes (each lane <= 64, no inter-lane carry).
+ *   - 8 production-shaped 16-elem blocks, fully unrolled.  Each block's
+ *     L_full/R_full load address is base + the exclusive prefix pulled from
+ *     the prefix word (a ubfx), so there is NO loop-carried lc/rc chain
+ *     across blocks.  iter-0 (vqtbl1) and iter-1 (vqtbl2 +
+ *     expand_tab_pre[nr0][m1]) bodies are byte-identical to production
+ *     merge_vec_vec_neon.
+ *   - bases advance once per 64-elem (8-byte) half by (rights, 64-rights).
+ * Tail (j+16 / j+8 / scalar) reuses the production loop shapes, continuing
+ * from the live lc/rc. */
+static inline void merge_neon_prefix128(const uint8_t *bm, int K,
+                                        const uint8_t *left, const uint8_t *right,
+                                        uint8_t *out) {
+    int lc = 0, rc = 0, j = 0;
+    for (; j + 128 <= K; j += 128) {
+        uint8x16_t bmv = vld1q_u8(bm + (j >> 3));
+        uint8x16_t pcv = vcntq_u8(bmv);
+
+        uint64x2_t bm64 = vreinterpretq_u64_u8(bmv);
+        uint64_t bm_lo = vgetq_lane_u64(bm64, 0);
+        uint64_t bm_hi = vgetq_lane_u64(bm64, 1);
+        uint64x2_t pc64 = vreinterpretq_u64_u8(pcv);
+        uint64_t pc_lo = vgetq_lane_u64(pc64, 0);
+        uint64_t pc_hi = vgetq_lane_u64(pc64, 1);
+
+        uint16x8_t pair = vpaddlq_u8(pcv);          /* 8 block right-counts */
+        uint64x2_t pr64 = vreinterpretq_u64_u16(pair);
+        uint64_t pref_lo = vgetq_lane_u64(pr64, 0) * 0x0001000100010001ULL;
+        uint64_t pref_hi = vgetq_lane_u64(pr64, 1) * 0x0001000100010001ULL;
+
+        /* One 16-elem production block.  EXCL = exclusive prefix (rights
+           consumed by earlier blocks in this half); EBASE = output offset
+           of the half (0 or 64).  base lc/rc are the half's start cursors. */
+        #define PFX_BLOCK(BMW, PCW, K_, EXCL, EBASE)                            \
+        do {                                                                    \
+            uint32_t excl_ = (EXCL);                                            \
+            uint8_t  m0  = (uint8_t)((BMW) >> (16 * (K_)));                      \
+            uint8_t  m1  = (uint8_t)((BMW) >> (16 * (K_) + 8));                  \
+            uint8_t  nr0 = (uint8_t)((PCW) >> (16 * (K_)));                      \
+            uint8x16_t L = vld1q_u8(left  + lc + (16 * (K_) - excl_));           \
+            uint8x16_t R = vld1q_u8(right + rc + excl_);                         \
+            uint8x16_t both0 = vcombine_u8(vget_low_u8(L), vget_low_u8(R));      \
+            uint8x8_t  o0 = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));           \
+            vst1_u8(out + j + (EBASE) + 16 * (K_), o0);                          \
+            uint8x16x2_t src = {{ L, R }};                                       \
+            uint8x8_t  o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));    \
+            vst1_u8(out + j + (EBASE) + 16 * (K_) + 8, o1);                      \
+        } while (0)
+
+        /* low half: blocks 0..3, base = entry lc/rc */
+        PFX_BLOCK(bm_lo, pc_lo, 0, 0,                        0);
+        PFX_BLOCK(bm_lo, pc_lo, 1, (pref_lo)       & 0xFFFF, 0);
+        PFX_BLOCK(bm_lo, pc_lo, 2, (pref_lo >> 16) & 0xFFFF, 0);
+        PFX_BLOCK(bm_lo, pc_lo, 3, (pref_lo >> 32) & 0xFFFF, 0);
+        uint32_t r_lo = (uint32_t)(pref_lo >> 48);
+        rc += r_lo; lc += 64 - r_lo;
+
+        /* high half: blocks 4..7 -> indices 0..3 of bm_hi, base = updated lc/rc */
+        PFX_BLOCK(bm_hi, pc_hi, 0, 0,                        64);
+        PFX_BLOCK(bm_hi, pc_hi, 1, (pref_hi)       & 0xFFFF, 64);
+        PFX_BLOCK(bm_hi, pc_hi, 2, (pref_hi >> 16) & 0xFFFF, 64);
+        PFX_BLOCK(bm_hi, pc_hi, 3, (pref_hi >> 32) & 0xFFFF, 64);
+        uint32_t r_hi = (uint32_t)(pref_hi >> 48);
+        rc += r_hi; lc += 64 - r_hi;
+        #undef PFX_BLOCK
+    }
+    /* ---- production tail, continuing from the live lc/rc ---- */
+    for (; j + 16 <= K; j += 16) {
+        uint8x16_t L_full = vld1q_u8(left + lc);
+        uint8x16_t R_full = vld1q_u8(right + rc);
+        uint8_t m0 = bm[j >> 3];
+        uint8x16_t both0 = vcombine_u8(vget_low_u8(L_full), vget_low_u8(R_full));
+        uint8x8_t  o0    = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));
+        vst1_u8(out + j, o0);
+        int nr0 = expand_popcnt[m0];
+        uint8_t m1 = bm[(j >> 3) + 1];
+        uint8x16x2_t src = {{ L_full, R_full }};
+        uint8x8_t o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));
+        vst1_u8(out + j + 8, o1);
+        int nr1 = expand_popcnt[m1];
+        rc += nr0 + nr1;
+        lc += (16 - nr0 - nr1);
+    }
+    for (; j + 8 <= K; j += 8) {
+        uint8_t m  = bm[j >> 3];
+        uint8x8_t  L    = vld1_u8(left + lc);
+        uint8x8_t  R    = vld1_u8(right + rc);
+        uint8x16_t both = vcombine_u8(L, R);
+        uint8x8_t  o    = vqtbl1_u8(both, vld1_u8(expand_tab[m]));
+        vst1_u8(out + j, o);
+        int nr = expand_popcnt[m];
+        rc += nr;
+        lc += (8 - nr);
+    }
+    for (; j < K; j++) {
+        int mb = (bm[j >> 3] >> (j & 7)) & 1;
+        out[j] = mb ? right[rc++] : left[lc++];
+    }
+}
+static void simd_merge_vec_vec_prefix (const ctx_t *c){
+    merge_neon_prefix128(c->bm, c->n, c->merge_left, c->merge_right, c->out);
+}
+
+/* cst_vec: left is a broadcast constant, right is the vector.  Single cursor
+   rc advances by right-counts (= popcount), so the prefix sum is over pcv
+   directly and rc advances by (pref >> 48) per half.  L side is Lbcast. */
+static inline void merge_neon_prefix128_cst_vec(const uint8_t *bm, int K,
+                                                uint8_t left_sym,
+                                                const uint8_t *right,
+                                                uint8_t *out) {
+    int rc = 0, j = 0;
+    uint8x8_t  Lbcast   = vdup_n_u8(left_sym);
+    uint8x16_t Lbcast_q = vdupq_n_u8(left_sym);
+    for (; j + 128 <= K; j += 128) {
+        uint8x16_t bmv = vld1q_u8(bm + (j >> 3));
+        uint8x16_t pcv = vcntq_u8(bmv);
+
+        uint64x2_t bm64 = vreinterpretq_u64_u8(bmv);
+        uint64_t bm_lo = vgetq_lane_u64(bm64, 0);
+        uint64_t bm_hi = vgetq_lane_u64(bm64, 1);
+        uint64x2_t pc64 = vreinterpretq_u64_u8(pcv);
+        uint64_t pc_lo = vgetq_lane_u64(pc64, 0);
+        uint64_t pc_hi = vgetq_lane_u64(pc64, 1);
+
+        uint16x8_t pair = vpaddlq_u8(pcv);          /* block right-counts */
+        uint64x2_t pr64 = vreinterpretq_u64_u16(pair);
+        uint64_t pref_lo = vgetq_lane_u64(pr64, 0) * 0x0001000100010001ULL;
+        uint64_t pref_hi = vgetq_lane_u64(pr64, 1) * 0x0001000100010001ULL;
+
+        #define PFX_BLOCK_CV(BMW, PCW, K_, EXCL, EBASE)                         \
+        do {                                                                    \
+            uint32_t excl_ = (EXCL);                                            \
+            uint8_t  m0  = (uint8_t)((BMW) >> (16 * (K_)));                      \
+            uint8_t  m1  = (uint8_t)((BMW) >> (16 * (K_) + 8));                  \
+            uint8_t  nr0 = (uint8_t)((PCW) >> (16 * (K_)));                      \
+            uint8x16_t R = vld1q_u8(right + rc + excl_);                         \
+            uint8x16_t both0 = vcombine_u8(Lbcast, vget_low_u8(R));              \
+            uint8x8_t  o0 = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));           \
+            vst1_u8(out + j + (EBASE) + 16 * (K_), o0);                          \
+            uint8x16x2_t src = {{ Lbcast_q, R }};                               \
+            uint8x8_t  o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));    \
+            vst1_u8(out + j + (EBASE) + 16 * (K_) + 8, o1);                      \
+        } while (0)
+
+        PFX_BLOCK_CV(bm_lo, pc_lo, 0, 0,                        0);
+        PFX_BLOCK_CV(bm_lo, pc_lo, 1, (pref_lo)       & 0xFFFF, 0);
+        PFX_BLOCK_CV(bm_lo, pc_lo, 2, (pref_lo >> 16) & 0xFFFF, 0);
+        PFX_BLOCK_CV(bm_lo, pc_lo, 3, (pref_lo >> 32) & 0xFFFF, 0);
+        rc += (uint32_t)(pref_lo >> 48);
+
+        PFX_BLOCK_CV(bm_hi, pc_hi, 0, 0,                        64);
+        PFX_BLOCK_CV(bm_hi, pc_hi, 1, (pref_hi)       & 0xFFFF, 64);
+        PFX_BLOCK_CV(bm_hi, pc_hi, 2, (pref_hi >> 16) & 0xFFFF, 64);
+        PFX_BLOCK_CV(bm_hi, pc_hi, 3, (pref_hi >> 32) & 0xFFFF, 64);
+        rc += (uint32_t)(pref_hi >> 48);
+        #undef PFX_BLOCK_CV
+    }
+    for (; j + 16 <= K; j += 16) {
+        uint8x16_t R_full = vld1q_u8(right + rc);
+        uint8_t m0 = bm[j >> 3];
+        uint8x16_t both0 = vcombine_u8(Lbcast, vget_low_u8(R_full));
+        uint8x8_t  o0    = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));
+        vst1_u8(out + j, o0);
+        int nr0 = expand_popcnt[m0];
+        uint8_t m1 = bm[(j >> 3) + 1];
+        uint8x16x2_t src = {{ Lbcast_q, R_full }};
+        uint8x8_t o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));
+        vst1_u8(out + j + 8, o1);
+        rc += nr0 + expand_popcnt[m1];
+    }
+    for (; j + 8 <= K; j += 8) {
+        uint8_t m  = bm[j >> 3];
+        uint8x8_t  R    = vld1_u8(right + rc);
+        uint8x16_t both = vcombine_u8(Lbcast, R);
+        uint8x8_t  o    = vqtbl1_u8(both, vld1_u8(expand_tab[m]));
+        vst1_u8(out + j, o);
+        rc += expand_popcnt[m];
+    }
+    for (; j < K; j++) {
+        int mb = (bm[j >> 3] >> (j & 7)) & 1;
+        out[j] = mb ? right[rc++] : left_sym;
+    }
+}
+static void simd_merge_cst_vec_prefix (const ctx_t *c){
+    merge_neon_prefix128_cst_vec(c->bm, c->n, MERGE_LEFT_SYM, c->merge_right, c->out);
+}
+
+/* vec_cst: left is the vector, right is a broadcast constant.  Single cursor
+   lc advances by left-counts (= 8 - popcount).  Subtract 8 - pcv BEFORE the
+   addp so the prefix sum is over left-counts directly: per-block offset is the
+   exclusive left-prefix as-is and lc advances by (pref >> 48) per half (no
+   16*k-excl, no 64-x).  R side is Rbcast.  nr0 still comes from raw pcv. */
+static inline void merge_neon_prefix128_vec_cst(const uint8_t *bm, int K,
+                                                const uint8_t *left,
+                                                uint8_t right_sym,
+                                                uint8_t *out) {
+    int lc = 0, j = 0;
+    uint8x8_t  Rbcast   = vdup_n_u8(right_sym);
+    uint8x16_t Rbcast_q = vdupq_n_u8(right_sym);
+    uint8x16_t eight    = vdupq_n_u8(8);
+    for (; j + 128 <= K; j += 128) {
+        uint8x16_t bmv = vld1q_u8(bm + (j >> 3));
+        uint8x16_t pcv = vcntq_u8(bmv);
+        uint8x16_t lcv = vsubq_u8(eight, pcv);      /* per-byte LEFT counts */
+
+        uint64x2_t bm64 = vreinterpretq_u64_u8(bmv);
+        uint64_t bm_lo = vgetq_lane_u64(bm64, 0);
+        uint64_t bm_hi = vgetq_lane_u64(bm64, 1);
+        uint64x2_t pc64 = vreinterpretq_u64_u8(pcv);
+        uint64_t pc_lo = vgetq_lane_u64(pc64, 0);
+        uint64_t pc_hi = vgetq_lane_u64(pc64, 1);
+
+        uint16x8_t pair = vpaddlq_u8(lcv);          /* block LEFT-counts */
+        uint64x2_t pr64 = vreinterpretq_u64_u16(pair);
+        uint64_t pref_lo = vgetq_lane_u64(pr64, 0) * 0x0001000100010001ULL;
+        uint64_t pref_hi = vgetq_lane_u64(pr64, 1) * 0x0001000100010001ULL;
+
+        #define PFX_BLOCK_VC(BMW, PCW, K_, EXCL, EBASE)                         \
+        do {                                                                    \
+            uint32_t excl_ = (EXCL);                                            \
+            uint8_t  m0  = (uint8_t)((BMW) >> (16 * (K_)));                      \
+            uint8_t  m1  = (uint8_t)((BMW) >> (16 * (K_) + 8));                  \
+            uint8_t  nr0 = (uint8_t)((PCW) >> (16 * (K_)));                      \
+            uint8x16_t L = vld1q_u8(left + lc + excl_);                          \
+            uint8x16_t both0 = vcombine_u8(vget_low_u8(L), Rbcast);              \
+            uint8x8_t  o0 = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));           \
+            vst1_u8(out + j + (EBASE) + 16 * (K_), o0);                          \
+            uint8x16x2_t src = {{ L, Rbcast_q }};                               \
+            uint8x8_t  o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));    \
+            vst1_u8(out + j + (EBASE) + 16 * (K_) + 8, o1);                      \
+        } while (0)
+
+        PFX_BLOCK_VC(bm_lo, pc_lo, 0, 0,                        0);
+        PFX_BLOCK_VC(bm_lo, pc_lo, 1, (pref_lo)       & 0xFFFF, 0);
+        PFX_BLOCK_VC(bm_lo, pc_lo, 2, (pref_lo >> 16) & 0xFFFF, 0);
+        PFX_BLOCK_VC(bm_lo, pc_lo, 3, (pref_lo >> 32) & 0xFFFF, 0);
+        lc += (uint32_t)(pref_lo >> 48);
+
+        PFX_BLOCK_VC(bm_hi, pc_hi, 0, 0,                        64);
+        PFX_BLOCK_VC(bm_hi, pc_hi, 1, (pref_hi)       & 0xFFFF, 64);
+        PFX_BLOCK_VC(bm_hi, pc_hi, 2, (pref_hi >> 16) & 0xFFFF, 64);
+        PFX_BLOCK_VC(bm_hi, pc_hi, 3, (pref_hi >> 32) & 0xFFFF, 64);
+        lc += (uint32_t)(pref_hi >> 48);
+        #undef PFX_BLOCK_VC
+    }
+    for (; j + 16 <= K; j += 16) {
+        uint8x16_t L_full = vld1q_u8(left + lc);
+        uint8_t m0 = bm[j >> 3];
+        uint8x16_t both0 = vcombine_u8(vget_low_u8(L_full), Rbcast);
+        uint8x8_t  o0    = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));
+        vst1_u8(out + j, o0);
+        int nr0 = expand_popcnt[m0];
+        uint8_t m1 = bm[(j >> 3) + 1];
+        uint8x16x2_t src = {{ L_full, Rbcast_q }};
+        uint8x8_t o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));
+        vst1_u8(out + j + 8, o1);
+        lc += (16 - nr0 - expand_popcnt[m1]);
+    }
+    for (; j + 8 <= K; j += 8) {
+        uint8_t m  = bm[j >> 3];
+        uint8x8_t  L    = vld1_u8(left + lc);
+        uint8x16_t both = vcombine_u8(L, Rbcast);
+        uint8x8_t  o    = vqtbl1_u8(both, vld1_u8(expand_tab[m]));
+        vst1_u8(out + j, o);
+        lc += (8 - expand_popcnt[m]);
+    }
+    for (; j < K; j++) {
+        int mb = (bm[j >> 3] >> (j & 7)) & 1;
+        out[j] = mb ? right_sym : left[lc++];
+    }
+}
+static void simd_merge_vec_cst_prefix (const ctx_t *c){
+    merge_neon_prefix128_vec_cst(c->bm, c->n, c->merge_left, MERGE_RIGHT_SYM, c->out);
+}
 #endif
 
 #if defined(HAVE_NEON_KERNELS)   /* partition family + unfused comparison (NEON only) */
@@ -794,6 +1079,9 @@ int main(int argc, char **argv) {
     reg("neon_pcpc",     ST_MERGE_VEC_VEC, 0, 0, simd_merge_vec_vec_pcpc_pure);
     reg("neon_pcpc_full",ST_MERGE_VEC_VEC, 0, 0, simd_merge_vec_vec_pcpc_full);
     reg("neon_unroll8",  ST_MERGE_VEC_VEC, 0, 0, simd_merge_vec_vec_unroll8);
+    reg("neon_prefix",   ST_MERGE_VEC_VEC, 0, 0, simd_merge_vec_vec_prefix);
+    reg("neon_prefix",   ST_MERGE_CST_VEC, 0, 0, simd_merge_cst_vec_prefix);
+    reg("neon_prefix",   ST_MERGE_VEC_CST, 0, 0, simd_merge_vec_cst_prefix);
     ensure_mask_to_bits();
     ensure_blend_tab();
     reg("neon_tbl",      ST_MERGE_CST_CST, 0, 0, simd_merge_cst_cst_tbl);

--- a/src/pivco_huffman_primitives_neon.h
+++ b/src/pivco_huffman_primitives_neon.h
@@ -82,19 +82,26 @@ static inline int popcount_K_right_neon(const uint8_t *bm, int nbytes, int K)
     return K_right;
 }
 
-/* merge_vec_vec_neon — V4 stride-16 main path.
+/* merge_vec_vec_neon — stride-128 prefix-sum main path + V4 stride-16 tail.
  *
- * Each iter loads 16-byte L_full / R_full once, produces two 8-byte
- * output halves.  Iter 0 uses vqtbl1 over vcombine(low(L_full),
- * low(R_full)) with the baseline expand_tab[m0].  Iter 1 uses vqtbl2
- * over the full 32-byte (L_full, R_full) with a PRECOMPUTED shuf
- * indexed by (nr0, m1) — collapses what would be ~4 runtime ALU ops
- * (the iter-0-induced shift adjustment) into one indexed load.  See
- * pivco_huffman_neon_tables.c for the (nr0, m1) table algebra.
+ * Main loop consumes 128 outputs/iter: ONE vld1q_u8 of 16 bitmap bytes, ONE
+ * vcntq_u8 for all 16 popcounts.  Bitmap + popcount are spilled to GPR halves,
+ * so m0/m1/nr0 come from ubfx instead of per-byte loads + the dependent
+ * expand_popcnt[] lookup.  vpaddlq_u8 folds adjacent byte popcounts into 8
+ * per-16-elem-block right-counts; a SWAR multiply by 0x0001000100010001 turns
+ * each 64-bit half (4× u16 lanes) into inclusive prefix sums, so every block's
+ * L_full/R_full load offset is a ubfx with NO loop-carried lc/rc chain.  The
+ * per-block iter-0 (vqtbl1) / iter-1 (vqtbl2 + expand_tab_pre[nr0][m1]) bodies
+ * are identical to the V4 path retained below.
  *
- * +13-15% bench gain on M4, +7-10% on Graviton 4 vs the older stride-
- * 16 path with 4 × vld_8 per iter.  See IDEAS.md "NEON bu_merge:
- * 16-byte loads + precomputed (nr0, m1) shuf — SHIPPED (2026-05-11)". */
+ * V4 stride-16 tail (handles the <128 remainder, and all of K<128): each iter
+ * loads 16-byte L_full / R_full once, two 8-byte halves; iter 1's vqtbl2 uses a
+ * PRECOMPUTED shuf indexed by (nr0, m1).  See pivco_huffman_neon_tables.c for
+ * the (nr0, m1) table algebra and IDEAS.md "NEON bu_merge: 16-byte loads +
+ * precomputed (nr0, m1) shuf — SHIPPED (2026-05-11)".
+ *
+ * Stride-128 path: +~26% over V4 in bench_prim on M1 Max (merge_vec_vec /
+ * cst_vec / vec_cst); M4 / Graviton 4 confirmation pending. */
 static inline void merge_vec_vec_neon(const uint8_t *bm, int K,
                                      const uint8_t *left,
                                      const uint8_t *right,
@@ -103,6 +110,54 @@ static inline void merge_vec_vec_neon(const uint8_t *bm, int K,
     PROF_TIC();
     int lc = 0, rc = 0;
     int j = 0;
+    /* Stride-128 prefix-sum main path (see header comment). */
+    for (; j + 128 <= K; j += 128) {
+        uint8x16_t bmv = vld1q_u8(bm + (j >> 3));
+        uint8x16_t pcv = vcntq_u8(bmv);
+
+        uint64x2_t bm64 = vreinterpretq_u64_u8(bmv);
+        uint64_t bm_lo = vgetq_lane_u64(bm64, 0);
+        uint64_t bm_hi = vgetq_lane_u64(bm64, 1);
+        uint64x2_t pc64 = vreinterpretq_u64_u8(pcv);
+        uint64_t pc_lo = vgetq_lane_u64(pc64, 0);
+        uint64_t pc_hi = vgetq_lane_u64(pc64, 1);
+
+        uint16x8_t pair = vpaddlq_u8(pcv);          /* block right-counts */
+        uint64x2_t pr64 = vreinterpretq_u64_u16(pair);
+        uint64_t pref_lo = vgetq_lane_u64(pr64, 0) * 0x0001000100010001ULL;
+        uint64_t pref_hi = vgetq_lane_u64(pr64, 1) * 0x0001000100010001ULL;
+
+        #define PFX_BLOCK(BMW, PCW, K_, EXCL, EBASE)                            \
+        do {                                                                    \
+            uint32_t excl_ = (EXCL);                                            \
+            uint8_t  m0  = (uint8_t)((BMW) >> (16 * (K_)));                      \
+            uint8_t  m1  = (uint8_t)((BMW) >> (16 * (K_) + 8));                  \
+            uint8_t  nr0 = (uint8_t)((PCW) >> (16 * (K_)));                      \
+            uint8x16_t L = vld1q_u8(left  + lc + (16 * (K_) - excl_));           \
+            uint8x16_t R = vld1q_u8(right + rc + excl_);                         \
+            uint8x16_t both0 = vcombine_u8(vget_low_u8(L), vget_low_u8(R));      \
+            uint8x8_t  o0 = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));           \
+            vst1_u8(out + j + (EBASE) + 16 * (K_), o0);                          \
+            uint8x16x2_t src = {{ L, R }};                                       \
+            uint8x8_t  o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));    \
+            vst1_u8(out + j + (EBASE) + 16 * (K_) + 8, o1);                      \
+        } while (0)
+
+        PFX_BLOCK(bm_lo, pc_lo, 0, 0,                        0);
+        PFX_BLOCK(bm_lo, pc_lo, 1, (pref_lo)       & 0xFFFF, 0);
+        PFX_BLOCK(bm_lo, pc_lo, 2, (pref_lo >> 16) & 0xFFFF, 0);
+        PFX_BLOCK(bm_lo, pc_lo, 3, (pref_lo >> 32) & 0xFFFF, 0);
+        uint32_t r_lo = (uint32_t)(pref_lo >> 48);
+        rc += r_lo; lc += 64 - r_lo;
+
+        PFX_BLOCK(bm_hi, pc_hi, 0, 0,                        64);
+        PFX_BLOCK(bm_hi, pc_hi, 1, (pref_hi)       & 0xFFFF, 64);
+        PFX_BLOCK(bm_hi, pc_hi, 2, (pref_hi >> 16) & 0xFFFF, 64);
+        PFX_BLOCK(bm_hi, pc_hi, 3, (pref_hi >> 32) & 0xFFFF, 64);
+        uint32_t r_hi = (uint32_t)(pref_hi >> 48);
+        rc += r_hi; lc += 64 - r_hi;
+        #undef PFX_BLOCK
+    }
     for (; j + 16 <= K; j += 16) {
         uint8x16_t L_full = vld1q_u8(left  + lc);
         uint8x16_t R_full = vld1q_u8(right + rc);
@@ -160,6 +215,52 @@ static inline void merge_cst_vec_neon(const uint8_t *bm, int K,
     int j = 0;
     uint8x8_t  Lbcast   = vdup_n_u8(left_sym);
     uint8x16_t Lbcast_q = vdupq_n_u8(left_sym);
+    /* Stride-128 prefix-sum main path: single cursor rc advances by right-counts
+       (= popcount), so the prefix sum is over pcv directly.  L side is Lbcast. */
+    for (; j + 128 <= K; j += 128) {
+        uint8x16_t bmv = vld1q_u8(bm + (j >> 3));
+        uint8x16_t pcv = vcntq_u8(bmv);
+
+        uint64x2_t bm64 = vreinterpretq_u64_u8(bmv);
+        uint64_t bm_lo = vgetq_lane_u64(bm64, 0);
+        uint64_t bm_hi = vgetq_lane_u64(bm64, 1);
+        uint64x2_t pc64 = vreinterpretq_u64_u8(pcv);
+        uint64_t pc_lo = vgetq_lane_u64(pc64, 0);
+        uint64_t pc_hi = vgetq_lane_u64(pc64, 1);
+
+        uint16x8_t pair = vpaddlq_u8(pcv);          /* block right-counts */
+        uint64x2_t pr64 = vreinterpretq_u64_u16(pair);
+        uint64_t pref_lo = vgetq_lane_u64(pr64, 0) * 0x0001000100010001ULL;
+        uint64_t pref_hi = vgetq_lane_u64(pr64, 1) * 0x0001000100010001ULL;
+
+        #define PFX_BLOCK_CV(BMW, PCW, K_, EXCL, EBASE)                         \
+        do {                                                                    \
+            uint32_t excl_ = (EXCL);                                            \
+            uint8_t  m0  = (uint8_t)((BMW) >> (16 * (K_)));                      \
+            uint8_t  m1  = (uint8_t)((BMW) >> (16 * (K_) + 8));                  \
+            uint8_t  nr0 = (uint8_t)((PCW) >> (16 * (K_)));                      \
+            uint8x16_t R = vld1q_u8(right + rc + excl_);                         \
+            uint8x16_t both0 = vcombine_u8(Lbcast, vget_low_u8(R));              \
+            uint8x8_t  o0 = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));           \
+            vst1_u8(out + j + (EBASE) + 16 * (K_), o0);                          \
+            uint8x16x2_t src = {{ Lbcast_q, R }};                               \
+            uint8x8_t  o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));    \
+            vst1_u8(out + j + (EBASE) + 16 * (K_) + 8, o1);                      \
+        } while (0)
+
+        PFX_BLOCK_CV(bm_lo, pc_lo, 0, 0,                        0);
+        PFX_BLOCK_CV(bm_lo, pc_lo, 1, (pref_lo)       & 0xFFFF, 0);
+        PFX_BLOCK_CV(bm_lo, pc_lo, 2, (pref_lo >> 16) & 0xFFFF, 0);
+        PFX_BLOCK_CV(bm_lo, pc_lo, 3, (pref_lo >> 32) & 0xFFFF, 0);
+        rc += (uint32_t)(pref_lo >> 48);
+
+        PFX_BLOCK_CV(bm_hi, pc_hi, 0, 0,                        64);
+        PFX_BLOCK_CV(bm_hi, pc_hi, 1, (pref_hi)       & 0xFFFF, 64);
+        PFX_BLOCK_CV(bm_hi, pc_hi, 2, (pref_hi >> 16) & 0xFFFF, 64);
+        PFX_BLOCK_CV(bm_hi, pc_hi, 3, (pref_hi >> 32) & 0xFFFF, 64);
+        rc += (uint32_t)(pref_hi >> 48);
+        #undef PFX_BLOCK_CV
+    }
     for (; j + 16 <= K; j += 16) {
         uint8x16_t R_full = vld1q_u8(right + rc);
         uint8_t m0 = bm[j >> 3];
@@ -204,6 +305,57 @@ static inline void merge_vec_cst_neon(const uint8_t *bm, int K,
     int j = 0;
     uint8x8_t  Rbcast   = vdup_n_u8(right_sym);
     uint8x16_t Rbcast_q = vdupq_n_u8(right_sym);
+    /* Stride-128 prefix-sum main path: single cursor lc advances by left-counts
+       (= 8 - popcount).  Subtract 8 - pcv BEFORE the addp so the prefix sums
+       count lefts directly (block offset is the exclusive left-prefix as-is, lc
+       advances by pref>>48 per half — no 16*k-excl, no 64-x).  R side is Rbcast;
+       nr0 still comes from raw pcv for expand_tab_pre[nr0][m1]. */
+    uint8x16_t eight = vdupq_n_u8(8);
+    for (; j + 128 <= K; j += 128) {
+        uint8x16_t bmv = vld1q_u8(bm + (j >> 3));
+        uint8x16_t pcv = vcntq_u8(bmv);
+        uint8x16_t lcv = vsubq_u8(eight, pcv);      /* per-byte LEFT counts */
+
+        uint64x2_t bm64 = vreinterpretq_u64_u8(bmv);
+        uint64_t bm_lo = vgetq_lane_u64(bm64, 0);
+        uint64_t bm_hi = vgetq_lane_u64(bm64, 1);
+        uint64x2_t pc64 = vreinterpretq_u64_u8(pcv);
+        uint64_t pc_lo = vgetq_lane_u64(pc64, 0);
+        uint64_t pc_hi = vgetq_lane_u64(pc64, 1);
+
+        uint16x8_t pair = vpaddlq_u8(lcv);          /* block LEFT-counts */
+        uint64x2_t pr64 = vreinterpretq_u64_u16(pair);
+        uint64_t pref_lo = vgetq_lane_u64(pr64, 0) * 0x0001000100010001ULL;
+        uint64_t pref_hi = vgetq_lane_u64(pr64, 1) * 0x0001000100010001ULL;
+
+        #define PFX_BLOCK_VC(BMW, PCW, K_, EXCL, EBASE)                         \
+        do {                                                                    \
+            uint32_t excl_ = (EXCL);                                            \
+            uint8_t  m0  = (uint8_t)((BMW) >> (16 * (K_)));                      \
+            uint8_t  m1  = (uint8_t)((BMW) >> (16 * (K_) + 8));                  \
+            uint8_t  nr0 = (uint8_t)((PCW) >> (16 * (K_)));                      \
+            uint8x16_t L = vld1q_u8(left + lc + excl_);                          \
+            uint8x16_t both0 = vcombine_u8(vget_low_u8(L), Rbcast);              \
+            uint8x8_t  o0 = vqtbl1_u8(both0, vld1_u8(expand_tab[m0]));           \
+            vst1_u8(out + j + (EBASE) + 16 * (K_), o0);                          \
+            uint8x16x2_t src = {{ L, Rbcast_q }};                               \
+            uint8x8_t  o1 = vqtbl2_u8(src, vld1_u8(expand_tab_pre[nr0][m1]));    \
+            vst1_u8(out + j + (EBASE) + 16 * (K_) + 8, o1);                      \
+        } while (0)
+
+        PFX_BLOCK_VC(bm_lo, pc_lo, 0, 0,                        0);
+        PFX_BLOCK_VC(bm_lo, pc_lo, 1, (pref_lo)       & 0xFFFF, 0);
+        PFX_BLOCK_VC(bm_lo, pc_lo, 2, (pref_lo >> 16) & 0xFFFF, 0);
+        PFX_BLOCK_VC(bm_lo, pc_lo, 3, (pref_lo >> 32) & 0xFFFF, 0);
+        lc += (uint32_t)(pref_lo >> 48);
+
+        PFX_BLOCK_VC(bm_hi, pc_hi, 0, 0,                        64);
+        PFX_BLOCK_VC(bm_hi, pc_hi, 1, (pref_hi)       & 0xFFFF, 64);
+        PFX_BLOCK_VC(bm_hi, pc_hi, 2, (pref_hi >> 16) & 0xFFFF, 64);
+        PFX_BLOCK_VC(bm_hi, pc_hi, 3, (pref_hi >> 32) & 0xFFFF, 64);
+        lc += (uint32_t)(pref_hi >> 48);
+        #undef PFX_BLOCK_VC
+    }
     for (; j + 16 <= K; j += 16) {
         uint8x16_t L_full = vld1q_u8(left + lc);
         uint8_t m0 = bm[j >> 3];


### PR DESCRIPTION
Summary
Replaces the V4 stride-16 main path in the three NEON binary-merge primitives with a stride-128, prefix-sum-driven kernel. On Apple M1 Max this is ~25% faster in isolation and +13.6% mean end-to-end pivco_bu decode on the distributions that use binary merge, with correctness unchanged (full test suite passes).

The merge step takes a partition bitmap plus the already-decoded left/right child streams and interleaves them into the parent stream — it runs at every internal tree node on the bottom-up decode path, so it's a large slice of decode time on moderate-entropy / real-text trees.

How it works
The old V4 path processed 16 outputs per iteration and had three costs on the critical path: a per-byte bitmap load, a dependent expand_popcnt[mask] table lookup, and a loop-carried lc/rc cursor chain (each block's child-stream load address depended on the previous block's). The new path attacks all three:

One vld1q_u8 loads 16 bitmap bytes; one vcntq_u8 produces all 16 popcounts. Bitmap and popcounts are spilled to GPR halves, so m0/m1/nr0 come from ubfx instead of per-byte loads + the expand_popcnt[] lookup.
vpaddlq_u8 folds adjacent byte-popcounts into 8 per-16-element-block right-counts; a SWAR multiply by 0x0001000100010001 turns each 64-bit half (4× u16 lanes) into inclusive prefix sums. Every block's L_full/R_full load offset then comes straight from the prefix word — no loop-carried cursor chain.
The per-block iter-0 (vqtbl1) / iter-1 (vqtbl2 + expand_tab_pre[nr0][m1]) bodies are byte-identical to V4.
vec_cst (vector-on-left) subtracts 8 - popcount before the addp so its single cursor sums lefts directly (no 64 - x); cst_vec (vector-on-right) sums popcounts directly.
The V4 stride-16 path is retained verbatim as the <128 tail and as the entire path for K < 128 nodes, so small nodes keep exactly the old behavior. merge_cst_cst is untouched (it loads no child streams).

Benchmarks
Isolated primitive microbench (pivco_bench_prim):
```
merge primitives — ns/elem, lower is better
M1 Max, Apple clang 16 -O3, bench_prim best-of-9, reps=4000, n=8192
primitive        V4 (old)   prefix (new)   speedup
-----------------------------------------------------
merge_vec_vec      0.0751      0.0554        -26%
merge_cst_vec      0.0632      0.0474        -25%
merge_vec_cst      0.0663      0.0498        -25%
merge_cst_cst      0.0305        —           unchanged (no L/R loads)
```
End-to-end decode (bench_main --all --tdbu, pivco_bu column):
```
pivco_bu decode throughput — M/s, higher is better
M1 Max, Apple clang 16 -O3; max of 3x reps=40
distribution       old      new       Δ
------------------------------------------
proba50           6062     7242    +19.5%
bell_s30          2784     3272    +17.5%
chinese_text      2795     3269    +17.0%
proba14           3460     4045    +16.9%
zipfian           2873     3357    +16.8%
geometric         3450     4027    +16.7%
json_api          2625     3061    +16.6%
prose_pride       3049     3533    +15.9%
english           3838     4412    +15.0%
html_wiki         2553     2905    +13.8%
log_apache        2746     3115    +13.4%
proba02           2867     3252    +13.4%
bell_s80          3779     4275    +13.1%
source_c          2895     3272    +13.0%
dna_fasta         4342     4867    +12.1%
bell_s10          3643     4027    +10.5%
image_jpeg        3274     3601    +10.0%
calgary_pic       2896     3125     +7.9%
csv_numeric       2634     2843     +7.9%
proba80           4040     4264     +5.5%
------------------------------------------  merge-path mean: +13.6%
gzip_random      10451    10623     +1.6%
flat_M5          14208    14319     +0.8%
flat_M6           9856     9867     +0.1%
flat_M3           9828     9815     -0.1%
sparse_4         31823    31715     -0.3%
sparse_16        31330    31237     -0.3%
two_sym_90/10     7779     7755     -0.3%
uniform          10612    10569     -0.4%
two_sym_eq       31542    31324     -0.7%
flat_M7           6959     6903     -0.8%
------------------------------------------  control mean:    -0.0%
```
The bottom group is the key control: `flat_*`, `sparse_*`, `two_sym_*`, `uniform`, and `gzip_random` run the flat-subtree / fast-path decoders and never call the binary-merge kernels — they sit at ~0% in the same runs. A thermal or measurement artifact would shift all 30 distributions uniformly; instead the gain lands only on the 20 that exercise the changed code, which rules out drift.

Testing
pivco_huffman_tests — ALL PASSED (0 failures), including adversarial-skew and FSE-dispatch roundtrips, exercising the j+8/scalar tails the microbench never reaches.
pivco_bench_prim validates every variant against a scalar reference (memcmp), passing across n = 1024 … 8176 (i.e. with the stride-16 remainder tail active).
Risk / not yet validated
Measured on Apple M1 Max only. The production NEON path is tuned for M4 / Graviton 4 (Neoverse-V2). A test-c8g A/B is the gate before merging to main and is still pending.
Behavior for K < 128 nodes is unchanged (V4 tail), so the risk is confined to large-node throughput on other µarches.
Scope
src/pivco_huffman_primitives_neon.h only — three function bodies + the merge_vec_vec_neon header comment. The experimental neon_prefix variants used to prove this in isolation land in the companion bench_prim commit (bench-neon-prefix-merge).