### PR TITLE
Draft: Scratch optimisation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ cmake --build build
 
 - **Backends**: scalar, NEON (ARM), x86 (SSE4.1 / AVX2), AVX-512 VBMI2 (Intel).  SVE is disabled (svcompact at 128-bit isn't competitive with NEON TBL).
 - **Codec framework**: one `pivco_huffman_codec.c` compiled per backend as an OBJECT library, each pulling in `primitives_<backend>.h` (the only file with SIMD intrinsics).  Runtime dispatcher in `src/pivco_huffman.c::resolve_impl` picks the best backend per host.
-- **Block size**: 8192 (ARM/AVX-512), 4096 (x86 SSE/AVX2) — auto-detected per backend at compile time
+- **Block size**: runtime knob (wire carries per-block N); default 32768 on all platforms since 2026-07-02 (the Apple 16K exception was retired with the in-place-merge + page-hazard-carve decode changes — see docs/BLOCK_SIZE.md)
 - **Wire format**: see `src/pivco_huffman_wire.h` for the canonical doc.  Per-node record: `[optional K_right:u16 LE][FSE marker:u8][bitmap or FSE payload]`.  Flat subtrees (D ≥ 2) skip the header and emit one N·D-bit packed region.
 - **Key data structures**:
   - `compress_tab[256][32]` combined shuffle table (TBL/pshufb partition; per-arch in `pivco_huffman_{neon,x86}_tables.c`)

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -36,6 +36,7 @@
 ### DONE — shipped
 
 **General**
+- [In-place merge + page-hazard carving; Apple 32K default](#in-place-merge--page-hazard-carving-apple-32k-default-2026-07-02)
 - [Fast Huffman builder (two-queue + radix, no min-heap)](#fast-huffman-builder-drop-the-index-indirected-min-heap-2026-06-21)
 - [Cross-port post-June-5 x86 optimizations to NEON](#cross-port-post-june-5-x86-optimizations-to-neon-2026-06-13)
 - [Unify-framework refactor (5 phases)](#unify-framework-refactor-2026-05-14)
@@ -221,6 +222,9 @@ RVV maps well: `vcompress` = partition, `vrgather` = TBL, **`vsuxei8` = native i
 ## DONE
 
 **General**
+
+### In-place merge + page-hazard carving; Apple 32K default, 2026-07-02
+Two decode-walk memory changes (concurrent-work findings #8/#9), then the block-size flip they unlock.  (1) `scratch_carve`: the merge kernels reload from each child cursor every iteration and a cursor parked on a page-boundary-straddling load pays 28-40 cycles/iter on Apple Silicon's 16 KB pages (~40% worst case on calgary_pic from placement alone) — child slices that would start within a cache line below a boundary, or sub-page slices that would cross one, get bumped to the next boundary; granularity = platform page size (16 KB Apple, 4 KB elsewhere), per-backend cursor-load widths (16 NEON/SSE/AVX2, 8 AVX-512, 1 scalar).  (2) In-place merge: a child at `out_buf + K_other` is never overtaken by the merge's writes (its read position stays ≥ the write position since the other side's consumed count ≤ K_other), and every backend's kernel loads before the chunk's store with monotone cursors — so one child per node decodes into out_buf's tail for free (either vec_vec child; the vec child of cst_vec/vec_cst spines, whose nested tails collapse onto the same memory).  Halves per-level scratch content and the merge working set; excluded at the root (no over-read slack in the caller's buffer).  That working-set cut removes the reason Apple defaulted to 16K blocks, so the `__APPLE__` gate was dropped — 32K everywhere.  M1 Max 32K+in-place vs old 16K default: +2..11% on 8/9 MAIN dists (slow dists +6..8%, dna −1.4%); M4: calgary_pic +8.8%, image_jpeg +8.1%, proba80 +4.1%, english/html/dna −1..−3% (within its 3-9% run spread).  In-place at 16K alone is ~−1% (old 16K files pay that on new decoders).  Apple-only measurements; EC2 fleet not re-swept.  See docs/BLOCK_SIZE.md.
 
 ### Fast Huffman builder (drop the index-indirected min-heap), 2026-06-21
 Replaced the freq→lengths min-heap (60–77% of `build_table`, all pointer-chasing) with LSD-radix sort + van Leeuwen two-queue + parent-walk depths (`build_lengths_twoqueue`, `4e0f288`) — ~2.5× uniform/zipf on the phase, roughly halving the table build.  Byte-identical: the `<=` tie-break reproduces the old heap's lengths (3M-case cross-check fuzz on M4/x86/NEON).  Same algorithm as zstd `HUF_buildTree`; its hybrid bucket sort was a wash-to-loss on x86, not adopted.  E2e weight ~1.5–2% under the per-128 KB re-table model (`bench_fair`), ~0.07% for one-global-table files.

--- a/docs/BLOCK_SIZE.md
+++ b/docs/BLOCK_SIZE.md
@@ -1,6 +1,6 @@
 # Block Size
 
-> **Last content review:** 2026-06-16 (full-fleet sweep, dynamic-block codec)
+> **Last content review:** 2026-07-02 (Apple exception retired — 32K everywhere)
 
 `PIVCO_BLOCK_SIZE` is the per-block symbol count. As of the dynamic-block
 work it is a **runtime** knob, not a compile-time limit:
@@ -10,9 +10,9 @@ work it is a **runtime** knob, not a compile-time limit:
   `[1, PIVCO_WIRE_MAX_N]` (`= 65535`, the uint16 wire-N cap) works with no
   recompile.
 - `PIVCO_BLOCK_SIZE` is now only the *default* chosen by the file codec,
-  CLI, and benchmarks. It defaults to **32768** on every architecture
-  except **Apple Silicon (macOS/arm64), which defaults to 16384** — see the
-  M4 exception below. An explicit `-DPIVCO_BLOCK_SIZE` overrides either.
+  CLI, and benchmarks. It defaults to **32768** on every architecture.
+  (Apple Silicon defaulted to 16384 from 2026-06-16 to 2026-07-02 — see the
+  retired exception below.) An explicit `-DPIVCO_BLOCK_SIZE` overrides it.
 - Streams are self-describing: the block size is written into the
   `.ph` header, and `pivcohuf_decompress` reads it back. A file made at one
   block size decodes on any build.
@@ -72,7 +72,7 @@ Geomean decode speedup vs an 8K block, across the `main` distribution set
 | c7g  | Graviton3 (NEON)         | −13% |   —  |  +8% | +12% | +13% | 64K  |
 | c8g  | Graviton4 (NEON)         | −12% |   —  |  +6% |  +8% |  +6% | 32K  |
 | m9g  | Graviton4+ (NEON)        | −10% |   —  |  +4% |  +5% |  +4% | 32K  |
-| M4   | Apple M4 (NEON)          |   *  |   —  | +3..16% per-dist | mixed (text regresses) | — | 16K |
+| M4   | Apple M4 (NEON)          |   *  |   —  | +3..16% per-dist | mixed pre-2026-07-02, now a win (see below) | — | 32K |
 
 Findings:
 
@@ -97,30 +97,38 @@ The lone regression is Sapphire Rapids (−3% at 32K; it peaks at 16K). 4K is
 worse for encode too (−5…−21%). So 32K is the right call on both axes: a win
 or wash everywhere for encode, with one −3% outlier.
 
-### The Apple Silicon exception (default 16K)
+### The Apple Silicon exception (16K, 2026-06-16 → 2026-07-02, retired)
 
-M4 is the one part that prefers **16K**: 32K regresses its text/medium-entropy
-distributions (and occasionally drops below 8K) because its very wide L1/L2
-already absorbs the per-block cost at 16K, after which the larger working set
-only hurts. So the default is gated: **macOS/arm64 → 16K, everything else →
-32K** (the cloud targets, including Graviton, want 32K).
+M4 used to prefer **16K**: 32K regressed its text/medium-entropy
+distributions because the per-block *scratch working set* of the BU decode
+walk grew with the block and spilled what its L1 absorbed at 16K.  The
+default was gated `#if defined(__APPLE__) && defined(__aarch64__)` → 16K.
 
-The gate is compile-time (`#if defined(__APPLE__) && defined(__aarch64__)` in
-`include/pivco_huffman.h`). That is exact, not a heuristic: a macOS arm64
-binary only ever runs on Apple Silicon, and a macOS binary's ISA is fixed at
-build time — so there is nothing a runtime probe could learn that the build
-doesn't already know. (CPU-ID asm doesn't help either: `MIDR_EL1` is EL1-only
-and faults at userspace on macOS; `sysctl hw.optional.arm64` is the only
-supported probe, and it still has to be `#ifdef __APPLE__`-guarded, collapsing
-back to the compile-time check.)
+The 2026-07-02 decode changes removed the cause rather than the symptom:
 
-Caveats / future work:
+- **In-place merge** (one child per node decodes into `out_buf`'s tail)
+  roughly halves the per-level scratch working set, and
+- **page-hazard-aware carving** keeps slow-moving merge cursors off
+  repeated 16 KB page-boundary splits (28-40 cycle penalty per load on
+  Apple Silicon; measured ~40% worst-case on calgary_pic from placement
+  alone).
 
-- Only **M4** was measured; M1–M3 are assumed to share the wide-L1 behaviour
-  and inherit the 16K default.
-- The *real* cause is cache size, not vendor. A principled **runtime gate
-  keyed on L1/L2 size** (`sysctl hw.l1dcachesize` on macOS,
-  `sysconf(_SC_LEVEL1_DCACHE_SIZE)` / sysfs on Linux) would generalise — e.g.
-  a future wide-L1 Graviton could also opt into 16K — and could supersede the
-  `__APPLE__` gate.
-- An explicit `-DPIVCO_BLOCK_SIZE=N` overrides the gate entirely.
+With those in, 32K beats the old 16K default on Apple Silicon and the
+gate was dropped — 32K everywhere.  Measured MAIN-set decode, 32K+in-place
+vs the prior 16K default (5 interleaved 20-rep rounds):
+
+- **M1 Max**: +2..11% on 8/9 dists; the slow dists gain most
+  (calgary_pic +8.4%, html_wiki +6.3%, chinese_text +7.4%, json_api
+  +7.5%, image_jpeg +11.4%); dna_fasta −1.4%.
+- **M4**: floor-raising — calgary_pic +8.8%, image_jpeg +8.1%, proba80
+  +4.1%, prose_pride/json_api +2.7%; english/html_wiki/dna −1..−3%
+  (M4 run-to-run spread was 3-9%, so the small negatives are at the
+  noise edge; the big positives are consistent across every run).
+- Ratio improves slightly at 32K (fewer per-block headers), as on the
+  rest of the fleet.
+
+Caveat: the in-place + carving numbers above are Apple-only measurements
+(M1 Max + M4).  The mechanism (fewer touched lines, hazard avoidance)
+should be neutral-to-positive on the smaller-L1 x86 parts, but the EC2
+fleet hasn't been re-swept with them — worth a re-run of this sweep next
+time the fleet is up.

--- a/include/pivco_huffman.h
+++ b/include/pivco_huffman.h
@@ -22,20 +22,16 @@ extern "C" {
  * parts + M4): every uarch peaks at or near 32K, and the fast modern AVX-512
  * parts regress past it (cache cliff).  See docs/BLOCK_SIZE.md.
  *
- * Apple M-series is the exception: 32K regresses its text dists (its wide
- * L1/L2 already absorbs the per-block cost at 16K, after which the larger
- * working set only hurts), so it defaults to 16K.  Gated compile-time on
- * macOS/arm64 — a macOS arm64 binary is always Apple Silicon, and a macOS
- * binary's ISA is fixed at build time, so the gate is exact.  An explicit
- * -DPIVCO_BLOCK_SIZE still wins (this whole block is #ifndef-guarded).
- * Only M4 was measured; M1–M3 are assumed to share the wide-L1 behaviour.
- * A principled runtime gate keyed on cache size (which is the real cause)
- * could supersede this later. */
-#if defined(__APPLE__) && defined(__aarch64__)
-#define PIVCO_BLOCK_SIZE 16384
-#else
+ * Apple M-series used to be the exception (16K): 32K regressed its text
+ * dists because the larger per-block scratch working set outgrew what its
+ * L1 absorbed.  The 2026-07-02 decode changes (in-place merge halving the
+ * scratch working set + page-hazard-aware carving) removed that regression:
+ * on M1 Max 32K is +2..11% on 8/9 MAIN dists (slow dists +6..8%); on M4
+ * the slowest dists gain most (calgary_pic +9%, image_jpeg +8%, proba80
+ * +4%) with english/dna ~1-3% down — floor-raising on both.  So Apple now
+ * shares the fleet-wide 32K default.  An explicit -DPIVCO_BLOCK_SIZE still
+ * wins (this whole block is #ifndef-guarded). */
 #define PIVCO_BLOCK_SIZE 32768
-#endif
 #endif
 
 /* Hard upper bound on a block's symbol count: the per-block wire header

--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -39,15 +39,45 @@
 static __thread uint8_t *g_decode_scratch     = NULL;
 static __thread size_t   g_decode_scratch_cap = 0;
 
+/* SCRATCH_PAGE is the page-split-load hazard granularity used by
+ * scratch_carve below: the hardware page size, because the penalty is
+ * two TLB translations per straddling load.  Apple Silicon pages are
+ * 16 KB (and its 28-40 cycle penalty is why this machinery exists);
+ * everything else in the fleet runs 4 KB pages.  Compile-time: a macOS
+ * arm64 binary is always Apple Silicon, so the gate is exact.  (A
+ * 64 KB-page Linux arm64 kernel gets 4 KB granularity — needless but
+ * harmless padding, no protection lost since 4 KB boundaries carry no
+ * penalty there.) */
+#if defined(__APPLE__) && defined(__aarch64__)
+#define SCRATCH_PAGE   ((uintptr_t)16384)
+#else
+#define SCRATCH_PAGE   ((uintptr_t)4096)
+#endif
+/* Widest load a merge kernel issues at a child-buffer cursor, from the
+ * backend's primitives header (16 NEON/SSE/AVX2, 8 AVX-512, 1 scalar).
+ * The cursor can rest AT `size` (exhausted side), so kernels read up to
+ * size + MERGE_OVERREAD - 1: this is the arena's trailing slack, the
+ * no-cross span, and the end-zone width.  START_GUARD is different — a
+ * heuristic, not a load width: keep the first ~cache line of every
+ * slice straddle-free because a cursor lingers NEAR offset 0 (not just
+ * at it) while the leading side drains. */
+#define MERGE_OVERREAD ((uintptr_t)PIVCO_PRIM_MERGE_OVERREAD)
+#define START_GUARD    ((uintptr_t)64)
+
+/* Returns a SCRATCH_PAGE-aligned base (the carve math needs
+ * page-relative offsets to be meaningful).  `need` must already include
+ * the carve-waste headroom; the page of alignment slack is added here. */
 static uint8_t *decode_scratch_ensure(size_t need)
 {
+    need += SCRATCH_PAGE;   /* base-alignment slack */
     if (need > g_decode_scratch_cap) {
         uint8_t *p = (uint8_t *)realloc(g_decode_scratch, need);
         if (!p) return NULL;
         g_decode_scratch     = p;
         g_decode_scratch_cap = need;
     }
-    return g_decode_scratch;
+    return (uint8_t *)(((uintptr_t)g_decode_scratch + (SCRATCH_PAGE - 1))
+                       & ~(SCRATCH_PAGE - 1));
 }
 
 /* Thread-local growable encode scratch arena.  Mirrors the decode arena
@@ -337,7 +367,40 @@ int CODEC_ENCODE_ENTRY(const uint8_t *symbols, size_t n,
  *   INTERNAL_FULL   — general merge: recurse both, merge
  *
  * `scratch_top` is the arena pointer for child output buffers; each
- * caller bumps it past its own K bytes when calling further down. */
+ * caller carves its children's slices off it (see scratch_carve) when
+ * calling further down. */
+
+/* ---------- Page-hazard-aware scratch carving ----------
+ *
+ * The merge kernels keep one read cursor per child buffer and reload a
+ * vector from BOTH cursors every iteration, advancing each by its side's
+ * popcount.  On a sparse bitmap one cursor can park in place for
+ * thousands of iterations; if the parked load straddles a page boundary,
+ * every iteration pays the split-load penalty (28-40 cycles on Apple
+ * Silicon's 16 KB pages — measured ~40% on calgary_pic from buffer
+ * placement alone).  How long a cursor dwells at one position scales
+ * with K_merge / size — a small slice's cursor is effectively parked
+ * EVERYWHERE inside it — so:
+ *
+ *   - sub-page slice: must not cross a boundary at all → bump to the
+ *     next boundary when it would (waste = distance to the boundary,
+ *     < size + MERGE_OVERREAD);
+ *   - page-crossing slice: interior straddles are unavoidable (and its
+ *     cursor moves fast anyway); bump to the boundary only when the
+ *     slice would START inside the START_GUARD straddle window.
+ *
+ * A bump wastes < size + MERGE_OVERREAD bytes, so the arena is sized 2x
+ * content plus slack (see CODEC_DECODE_ENTRY). */
+static inline uint8_t *scratch_carve(uint8_t **top, int size)
+{
+    uintptr_t p   = (uintptr_t)*top;
+    uintptr_t rem = SCRATCH_PAGE - (p & (SCRATCH_PAGE - 1));      /* 1..PAGE */
+    if ((uintptr_t)size + MERGE_OVERREAD > rem &&
+        ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE || rem < START_GUARD))
+        p += rem;   /* start the slice on the next page boundary */
+    *top = (uint8_t *)(p + (uintptr_t)size);
+    return (uint8_t *)p;
+}
 
 static void codec_decode_subtree(const pivco_huffman_table_t *table,
                                    int16_t node_id, int K,
@@ -395,9 +458,9 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
                                    out_buf);
             return;
         }
-        uint8_t *right_buf = scratch_top;
+        uint8_t *right_buf = scratch_carve(&scratch_top, K_right);
         codec_decode_subtree(table, node->right, K_right,
-                              right_buf, in_ptr, scratch_top + K_right);
+                              right_buf, in_ptr, scratch_top);
         prim_merge_cst_vec(bm, K, table->prefill_sym,
                                     right_buf, out_buf);
         return;
@@ -415,9 +478,9 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
             return;
         }
         int K_left = K - K_right;
-        uint8_t *left_buf = scratch_top;
+        uint8_t *left_buf = scratch_carve(&scratch_top, K_left);
         codec_decode_subtree(table, node->left, K_left,
-                              left_buf, in_ptr, scratch_top + K_left);
+                              left_buf, in_ptr, scratch_top);
         prim_merge_vec_cst(bm, K, left_buf,
                                      table->prefill_sym, out_buf);
         return;
@@ -441,9 +504,9 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
             return;
         }
         if (left_kind == (uint8_t)PIVCO_NODE_LEAF) {
-            uint8_t *right_buf = scratch_top;
+            uint8_t *right_buf = scratch_carve(&scratch_top, K_right);
             codec_decode_subtree(table, node->right, K_right,
-                                  right_buf, in_ptr, scratch_top + K_right);
+                                  right_buf, in_ptr, scratch_top);
             prim_merge_cst_vec(bm, K,
                                         (uint8_t)table->tree[node->left].symbol,
                                         right_buf, out_buf);
@@ -451,9 +514,9 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         }
         if (right_kind == (uint8_t)PIVCO_NODE_LEAF) {
             int K_left = K - K_right;
-            uint8_t *left_buf = scratch_top;
+            uint8_t *left_buf = scratch_carve(&scratch_top, K_left);
             codec_decode_subtree(table, node->left, K_left,
-                                  left_buf, in_ptr, scratch_top + K_left);
+                                  left_buf, in_ptr, scratch_top);
             prim_merge_vec_cst(bm, K, left_buf,
                                          (uint8_t)table->tree[node->right].symbol,
                                          out_buf);
@@ -463,14 +526,13 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         /* General case: both children non-leaf.  Recurse into both
          * with disjoint scratch slices, then merge. */
         int K_left = K - K_right;
-        uint8_t *left_buf  = scratch_top;
-        uint8_t *right_buf = scratch_top + K_left;
-        uint8_t *new_scratch_top = scratch_top + K;
+        uint8_t *left_buf  = scratch_carve(&scratch_top, K_left);
+        uint8_t *right_buf = scratch_carve(&scratch_top, K_right);
 
         codec_decode_subtree(table, node->left,  K_left,
-                              left_buf,  in_ptr, new_scratch_top);
+                              left_buf,  in_ptr, scratch_top);
         codec_decode_subtree(table, node->right, K_right,
-                              right_buf, in_ptr, new_scratch_top);
+                              right_buf, in_ptr, scratch_top);
         prim_merge_vec_vec(bm, K, left_buf, right_buf, out_buf);
         return;
     }
@@ -528,8 +590,10 @@ int CODEC_DECODE_ENTRY(const uint8_t *in, size_t in_len,
      * partition is one-sided so a single recursion can consume up to
      * N bytes.  Bounded by (MAX_CODE_LEN+2) * N.  Grown on demand from a
      * thread-local heap buffer so block size is a runtime parameter. */
+    /* Doubled for scratch_carve's page bumps: a level's two carves waste
+     * < K_left + K_right + 2*MERGE_OVERREAD <= N + 128 extra. */
     uint8_t *scratch =
-        decode_scratch_ensure((size_t)N * (PIVCO_MAX_CODE_LEN + 2));
+        decode_scratch_ensure((2 * (size_t)N + 128) * (PIVCO_MAX_CODE_LEN + 2));
     if (!scratch) return PIVCO_ERR_NULL;
 
     codec_decode_subtree(table, table->tree_root, N,

--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -402,11 +402,47 @@ static inline uint8_t *scratch_carve(uint8_t **top, int size)
     return (uint8_t *)p;
 }
 
+/* ---------- In-place merge: child buffers in out_buf's tail ----------
+ *
+ * A merge's writes sweep out_buf from the start while each input cursor
+ * advances by its side's popcount, so a child placed at out_buf's TAIL
+ * is never overtaken: with the child at out_buf + K_other, its read
+ * position K_other + c stays >= the write position c_left + c_right
+ * because the OTHER side's consumed count can't exceed K_other.  Every
+ * backend's merge kernel loads its vector(s) before the chunk's store
+ * and advances monotonically, so reads never touch stored bytes (and no
+ * kernel over-stores its out_buf — all store loops are strictly
+ * bounded, which matters because a tail's end abuts the parent's data).
+ * This holds for either child of a vec_vec merge and for the single vec
+ * child of a cst_vec / vec_cst merge — one child per node can live in
+ * out_buf for free, and nested tails collapse a spine of such nodes
+ * onto the same memory.  Only the shorter vec_vec child needs scratch:
+ * peak scratch content drops from ~K to ~K/2 per level and the merge
+ * working set shrinks accordingly.
+ *
+ * Two exclusions: the root call (out_buf is the caller's buffer, which
+ * is only guaranteed N bytes — the kernels' trailing over-read must
+ * stay inside our arena), and hazard-prone placements (same page test
+ * as scratch_carve; falls back to a carve).  See #9. */
+static inline uint8_t *place_tail(uint8_t *out_buf, int offset, int size,
+                                  uint8_t **top)
+{
+    uint8_t *p = out_buf + offset;
+    uintptr_t rem = SCRATCH_PAGE - ((uintptr_t)p & (SCRATCH_PAGE - 1));
+    if ((uintptr_t)size + MERGE_OVERREAD > rem &&
+        ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE || rem < START_GUARD))
+        return scratch_carve(top, size);
+    return p;
+}
+
+/* `tail_ok` — nonzero when out_buf is arena-backed (a carve or a nested
+ * tail), i.e. a child may be placed in its tail (see place_tail).  The
+ * root call passes 0: the caller's output buffer has no over-read slack. */
 static void codec_decode_subtree(const pivco_huffman_table_t *table,
                                    int16_t node_id, int K,
                                    uint8_t *out_buf,
                                    const uint8_t **in_ptr,
-                                   uint8_t *scratch_top)
+                                   uint8_t *scratch_top, int tail_ok)
 {
     if (K == 0) return;
 
@@ -458,9 +494,11 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
                                    out_buf);
             return;
         }
-        uint8_t *right_buf = scratch_carve(&scratch_top, K_right);
+        uint8_t *right_buf = tail_ok
+            ? place_tail(out_buf, K - K_right, K_right, &scratch_top)
+            : scratch_carve(&scratch_top, K_right);
         codec_decode_subtree(table, node->right, K_right,
-                              right_buf, in_ptr, scratch_top);
+                              right_buf, in_ptr, scratch_top, 1);
         prim_merge_cst_vec(bm, K, table->prefill_sym,
                                     right_buf, out_buf);
         return;
@@ -478,9 +516,11 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
             return;
         }
         int K_left = K - K_right;
-        uint8_t *left_buf = scratch_carve(&scratch_top, K_left);
+        uint8_t *left_buf = tail_ok
+            ? place_tail(out_buf, K_right, K_left, &scratch_top)
+            : scratch_carve(&scratch_top, K_left);
         codec_decode_subtree(table, node->left, K_left,
-                              left_buf, in_ptr, scratch_top);
+                              left_buf, in_ptr, scratch_top, 1);
         prim_merge_vec_cst(bm, K, left_buf,
                                      table->prefill_sym, out_buf);
         return;
@@ -504,9 +544,11 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
             return;
         }
         if (left_kind == (uint8_t)PIVCO_NODE_LEAF) {
-            uint8_t *right_buf = scratch_carve(&scratch_top, K_right);
+            uint8_t *right_buf = tail_ok
+                ? place_tail(out_buf, K - K_right, K_right, &scratch_top)
+                : scratch_carve(&scratch_top, K_right);
             codec_decode_subtree(table, node->right, K_right,
-                                  right_buf, in_ptr, scratch_top);
+                                  right_buf, in_ptr, scratch_top, 1);
             prim_merge_cst_vec(bm, K,
                                         (uint8_t)table->tree[node->left].symbol,
                                         right_buf, out_buf);
@@ -514,25 +556,41 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         }
         if (right_kind == (uint8_t)PIVCO_NODE_LEAF) {
             int K_left = K - K_right;
-            uint8_t *left_buf = scratch_carve(&scratch_top, K_left);
+            uint8_t *left_buf = tail_ok
+                ? place_tail(out_buf, K_right, K_left, &scratch_top)
+                : scratch_carve(&scratch_top, K_left);
             codec_decode_subtree(table, node->left, K_left,
-                                  left_buf, in_ptr, scratch_top);
+                                  left_buf, in_ptr, scratch_top, 1);
             prim_merge_vec_cst(bm, K, left_buf,
                                          (uint8_t)table->tree[node->right].symbol,
                                          out_buf);
             return;
         }
 
-        /* General case: both children non-leaf.  Recurse into both
-         * with disjoint scratch slices, then merge. */
+        /* General case: both children non-leaf.  The longer child
+         * decodes into out_buf's tail (free — see place_tail), the
+         * shorter into a scratch carve; then merge.  Decode order stays
+         * left-then-right (the wire is pre-order) — only buffer
+         * placement differs.  Both recursions get the same scratch_top:
+         * they run sequentially and a child's deep scratch is dead once
+         * it returns. */
         int K_left = K - K_right;
-        uint8_t *left_buf  = scratch_carve(&scratch_top, K_left);
-        uint8_t *right_buf = scratch_carve(&scratch_top, K_right);
+        uint8_t *left_buf, *right_buf;
+        if (tail_ok && K_left >= K_right) {
+            left_buf  = place_tail(out_buf, K_right, K_left, &scratch_top);
+            right_buf = scratch_carve(&scratch_top, K_right);
+        } else if (tail_ok) {
+            right_buf = place_tail(out_buf, K_left, K_right, &scratch_top);
+            left_buf  = scratch_carve(&scratch_top, K_left);
+        } else {
+            left_buf  = scratch_carve(&scratch_top, K_left);
+            right_buf = scratch_carve(&scratch_top, K_right);
+        }
 
         codec_decode_subtree(table, node->left,  K_left,
-                              left_buf,  in_ptr, scratch_top);
+                              left_buf,  in_ptr, scratch_top, 1);
         codec_decode_subtree(table, node->right, K_right,
-                              right_buf, in_ptr, scratch_top);
+                              right_buf, in_ptr, scratch_top, 1);
         prim_merge_vec_vec(bm, K, left_buf, right_buf, out_buf);
         return;
     }
@@ -597,7 +655,7 @@ int CODEC_DECODE_ENTRY(const uint8_t *in, size_t in_len,
     if (!scratch) return PIVCO_ERR_NULL;
 
     codec_decode_subtree(table, table->tree_root, N,
-                          symbols, &ptr, scratch);
+                          symbols, &ptr, scratch, /*tail_ok=*/0);
 
     *consumed = (size_t)(ptr - in);
     return PIVCO_OK;

--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -386,18 +386,45 @@ int CODEC_ENCODE_ENTRY(const uint8_t *symbols, size_t n,
  *     next boundary when it would (waste = distance to the boundary,
  *     < size + MERGE_OVERREAD);
  *   - page-crossing slice: interior straddles are unavoidable (and its
- *     cursor moves fast anyway); bump to the boundary only when the
- *     slice would START inside the START_GUARD straddle window.
+ *     cursor moves fast anyway); keep just the START (a cursor lingers
+ *     near offset 0) and the END (an exhausted side reloads from
+ *     exactly `size` until the merge finishes) straddle-free with
+ *     small nudges — the end lands ON a boundary, so the end-position
+ *     load reads the next page without straddling.
  *
- * A bump wastes < size + MERGE_OVERREAD bytes, so the arena is sized 2x
- * content plus slack (see CODEC_DECODE_ENTRY). */
+ * ALL padding draws from a per-block budget (g_scratch_pad_left, reset
+ * in CODEC_DECODE_ENTRY): when it runs out, slices are placed unpadded —
+ * a perf hazard reachable only by adversarial page phases, never a
+ * safety issue.  The budget caps total padding, which is what lets the
+ * arena shrink to 2N + budget (see CODEC_DECODE_ENTRY). */
+/* Absolute (not per-page) so the 2N + budget arena bound is identical
+ * on every platform; 16 KB regardless of SCRATCH_PAGE. */
+#define PIVCO_SCRATCH_PAD_BUDGET ((size_t)16384)
+static __thread size_t g_scratch_pad_left;
+
 static inline uint8_t *scratch_carve(uint8_t **top, int size)
 {
     uintptr_t p   = (uintptr_t)*top;
     uintptr_t rem = SCRATCH_PAGE - (p & (SCRATCH_PAGE - 1));      /* 1..PAGE */
-    if ((uintptr_t)size + MERGE_OVERREAD > rem &&
-        ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE || rem < START_GUARD))
-        p += rem;   /* start the slice on the next page boundary */
+    uintptr_t pad = 0;
+    if ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE) {
+        if ((uintptr_t)size + MERGE_OVERREAD > rem)
+            pad = rem;                                  /* sub-page: never cross */
+    } else {
+        if (rem < START_GUARD) pad = rem;               /* clean start */
+        uintptr_t end  = p + pad + (uintptr_t)size;
+        uintptr_t erem = SCRATCH_PAGE - (end & (SCRATCH_PAGE - 1));
+        if (erem < MERGE_OVERREAD) {
+            pad += erem;                                /* end onto boundary */
+            uintptr_t srem = SCRATCH_PAGE - ((p + pad) & (SCRATCH_PAGE - 1));
+            if (srem < START_GUARD) pad += srem;        /* re-clean start; end
+                                                           stays clean (moves to
+                                                           < START_GUARD past
+                                                           the boundary) */
+        }
+    }
+    if (pad <= g_scratch_pad_left) g_scratch_pad_left -= pad; else pad = 0;
+    p += pad;
     *top = (uint8_t *)(p + (uintptr_t)size);
     return (uint8_t *)p;
 }
@@ -420,18 +447,33 @@ static inline uint8_t *scratch_carve(uint8_t **top, int size)
  * peak scratch content drops from ~K to ~K/2 per level and the merge
  * working set shrinks accordingly.
  *
- * Two exclusions: the root call (out_buf is the caller's buffer, which
+ * One exclusion: the root call (out_buf is the caller's buffer, which
  * is only guaranteed N bytes — the kernels' trailing over-read must
- * stay inside our arena), and hazard-prone placements (same page test
- * as scratch_carve; falls back to a carve).  See #9. */
+ * stay inside our arena).  See #9.
+ *
+ * A tail's position is fixed by the invariant (exactly out_buf +
+ * K_other), so it cannot be nudged.  Its END coincides with its nearest
+ * carved ancestor's end, which scratch_carve keeps straddle-free, and a
+ * page-crossing tail's start-zone risk (~63/SCRATCH_PAGE per node) is
+ * accepted like any large slice's.  The one dangerous case is a
+ * SUB-PAGE tail that would cross a boundary — a small slice's cursor is
+ * parked everywhere in it (e.g. the 128-byte side of a 32K merge dwells
+ * ~256 iterations per position) — that one falls back to a no-cross
+ * carve, charging the extra scratch content to the SAME pad budget so
+ * the 2N + budget arena bound stays intact (an unbudgeted fallback
+ * chain would break the S(K) <= K induction; see CODEC_DECODE_ENTRY). */
 static inline uint8_t *place_tail(uint8_t *out_buf, int offset, int size,
                                   uint8_t **top)
 {
     uint8_t *p = out_buf + offset;
-    uintptr_t rem = SCRATCH_PAGE - ((uintptr_t)p & (SCRATCH_PAGE - 1));
-    if ((uintptr_t)size + MERGE_OVERREAD > rem &&
-        ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE || rem < START_GUARD))
-        return scratch_carve(top, size);
+    if ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE) {
+        uintptr_t rem = SCRATCH_PAGE - ((uintptr_t)p & (SCRATCH_PAGE - 1));
+        if ((uintptr_t)size + MERGE_OVERREAD > rem &&
+            (size_t)size <= g_scratch_pad_left) {
+            g_scratch_pad_left -= (size_t)size;   /* charge the content... */
+            return scratch_carve(top, size);      /* ...the carve pads itself */
+        }
+    }
     return p;
 }
 
@@ -644,16 +686,31 @@ int CODEC_DECODE_ENTRY(const uint8_t *in, size_t in_len,
         return PIVCO_OK;
     }
 
-    /* Scratch arena.  Worst case at a heavily-skewed node, the
-     * partition is one-sided so a single recursion can consume up to
-     * N bytes.  Bounded by (MAX_CODE_LEN+2) * N.  Grown on demand from a
-     * thread-local heap buffer so block size is a runtime parameter. */
-    /* Doubled for scratch_carve's page bumps: a level's two carves waste
-     * < K_left + K_right + 2*MERGE_OVERREAD <= N + 128 extra. */
-    uint8_t *scratch =
-        decode_scratch_ensure((2 * (size_t)N + 128) * (PIVCO_MAX_CODE_LEN + 2));
+    /* Scratch arena: 2N content + pad budget + trailing over-read.
+     *
+     * Content bound: let S(K) = peak scratch while decoding a subtree
+     * whose out_buf is arena-backed.  Leaves and both-leaf merges
+     * consume 0; a half/cst-side child lives in out_buf's tail, so
+     * S(K) = S(K_c) with K_c < K; a full node carves only its shorter
+     * child m and tail-places the longer M, so S(K) = m + max(S(m),
+     * S(M)).  By induction S(K) <= m + max(m, M) = K.  The root is the
+     * exception (tail_ok = 0): it carves both children, adding
+     * K_l + K_r = N, so the peak is N + max(S(K_l), S(K_r)) <= 2N.
+     * (place_tail must never fall back outside the pad budget — that
+     * would break the induction.)
+     *
+     * Slack: every page-hazard action — no-cross bumps and start/end
+     * nudges in scratch_carve, and small-tail fallback carves in
+     * place_tail — draws from the per-block PIVCO_SCRATCH_PAD_BUDGET,
+     * so their total is capped by construction; the topmost slice's
+     * trailing over-read needs MERGE_OVERREAD in-arena.  Grown on
+     * demand from a thread-local heap buffer so block size is a
+     * runtime parameter. */
+    uint8_t *scratch = decode_scratch_ensure(
+        2 * (size_t)N + PIVCO_SCRATCH_PAD_BUDGET + MERGE_OVERREAD);
     if (!scratch) return PIVCO_ERR_NULL;
 
+    g_scratch_pad_left = PIVCO_SCRATCH_PAD_BUDGET;
     codec_decode_subtree(table, table->tree_root, N,
                           symbols, &ptr, scratch, /*tail_ok=*/0);
 

--- a/src/pivco_huffman_primitives_avx512.h
+++ b/src/pivco_huffman_primitives_avx512.h
@@ -58,6 +58,12 @@
 #include "pivco_huffman_x86_tables.h"      /* expand_tab for BU tail */
 #include "pivco_huffman_avx512_flat.h"     /* flat_d{2,3,4,5,6}_unpack_avx512* */
 #include "pivco_huffman_avx512_pack.h"     /* pack_d{2..7}_avx512 — vpmultishiftqb */
+
+/* Widest load the AVX-512 merge kernels issue at a child-buffer
+ * cursor: the 64-byte main loops use maskz_expandloadu (reads exactly
+ * the consumed byte count — no over-read at all); the stride-16/8
+ * tails use 8-byte loadl_epi64, and the cursor can rest AT `size`. */
+#define PIVCO_PRIM_MERGE_OVERREAD 8
 #include "pivco_prof.h"
 
 #include <immintrin.h>

--- a/src/pivco_huffman_primitives_neon.h
+++ b/src/pivco_huffman_primitives_neon.h
@@ -29,6 +29,11 @@
 #include <stdint.h>
 #include <string.h>
 
+/* Widest load the NEON merge kernels issue at a child-buffer cursor:
+ * one 16-byte vld1q.  The cursor can rest AT `size` (exhausted side of
+ * a merge keeps reloading there), so kernels read up to size+15. */
+#define PIVCO_PRIM_MERGE_OVERREAD 16
+
 /* Backend lifecycle.  Lazily build the compress_tab + expand_tab pre-
  * bake tables that the NEON partition / merge primitives index
  * into.  Idempotent and cheap after the first call. */

--- a/src/pivco_huffman_primitives_scalar.h
+++ b/src/pivco_huffman_primitives_scalar.h
@@ -17,6 +17,12 @@
 #include <stdint.h>
 #include <string.h>
 
+/* Widest load the scalar kernels issue at a child-buffer cursor: none —
+ * the byte loops read an element only when consumed < size, and 1-byte
+ * loads cannot straddle a page anyway.  1 keeps the codec's carve math
+ * degenerate-but-valid (empty straddle zones, minimal arena slack). */
+#define PIVCO_PRIM_MERGE_OVERREAD 1
+
 /* Backend lifecycle.  Scalar has no runtime tables to lazy-init. */
 static inline void codec_init_scalar(void) { /* no-op */ }
 

--- a/src/pivco_huffman_primitives_x86.h
+++ b/src/pivco_huffman_primitives_x86.h
@@ -46,6 +46,11 @@
 #include <string.h>
 #include <assert.h>
 
+/* Widest load the SSE/AVX2 merge kernels issue at a child-buffer
+ * cursor: 16 bytes (loadu_si128; the AVX2 loops load two 16-byte
+ * halves).  The cursor can rest AT `size`, so reads reach size+15. */
+#define PIVCO_PRIM_MERGE_OVERREAD 16
+
 /* Backend lifecycle.  Lazily build the compress_tab + expand_tab pre-
  * bake tables that the x86 partition / merge primitives index
  * into.  Idempotent and cheap after the first call. */


### PR DESCRIPTION
I tried using Fable to address #8 and #9, and increase chunk size.

Mostly for discussions/thoughts.

Applicability of the page-crossing-optimisation is low, and complexity of `scratch_carve` is high, but this does reduce the scratch size, reduce the number and variability of cross-page-loads, make chunk size consistent, and claim a performance improvement on Apple Silicon. Which is basically everything I was hoping for, so maybe it's a good change.

The big question is x86. Trying to avoid page crossing there is likely a mistake, but I haven't tested.

## Split loads per 4 M-symbol pass

| dist          | total loads | before@16K | before@32K | after@16K | after@32K | bad_inplace@32K |
|---------------|------------:|-----------:|-----------:|----------:|----------:|----------------:|
| proba80       |       327 K |          0 |          0 |     **0** |     **0** |           1 938 |
| english       |      1.05 M |        754 |        845 |     **0** |   **374** |             936 |
| html_wiki     |      1.58 M |        911 |      1 120 |     **0** |   **559** |           1 291 |
| prose_pride   |      1.53 M |      1 028 |      1 022 |     **0** |   **422** |           1 589 |
| image_jpeg    |      1.01 M |        434 |        701 |     **0** |   **266** |             912 |
| json_api      |      1.64 M |        706 |      1 146 |     **0** |   **536** |           1 406 |
| dna_fasta     |       722 K |        400 |        456 |     **0** |   **299** |             925 |
| chinese_text  |      1.59 M |        738 |        840 |     **0** |   **453** |           1 302 |
| calgary_pic   |       449 K |         32 |        133 |     **0** |     **0** |      **21 222** |

(`bad_inplace` was my old attempted in-place merge, that was using the end of the output buffer)