### PR TITLE
Draft: Sapphire Rapids non-64-byte aligned output buffer hazard

### DIFF
--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -449,6 +449,38 @@ int CODEC_ENCODE_ENTRY(const uint8_t *symbols, size_t n,
  * is on.  The root call passes 0 -- the caller's output buffer has no
  * over-read slack. */
 
+/* ---------- Root-merge store-alignment peel ----------
+ *
+ * The root merge (node_id == tree_root, the only invocation whose
+ * out_buf is CALLER memory) streams wide SIMD stores into `symbols`;
+ * every other merge writes layout-fixed scratch.  When `symbols` is
+ * not 64-byte-aligned every wide store splits a cache line — a 13-16%
+ * x86 decode tax that comes and goes with the caller's allocator luck,
+ * since malloc guarantees only 16 bytes (the "allocation lottery"; see
+ * PIVCO_MERGE_ALIGN_PEEL in pivco_huffman_common.h and
+ * results/exp_alloc7 on the ping-pong-results branch).
+ *
+ * Fix: decode the first (-symbols & 63) symbols branchlessly (root
+ * bitmaps can be ~50/50, so a branchy peel would mispredict its way
+ * out of the win), then hand the kernel a line-aligned destination.
+ * The peel is a multiple of 8 so the bitmap handoff stays
+ * byte-aligned; reading up to `peel` bytes ahead of a vec cursor is
+ * safe for regions >= 64 bytes (guarded at the sites; at the root,
+ * tail_ok=0 means children were carved from scratch, disjoint from
+ * symbols).  x86 backends only: NEON's 8/16-byte stores at >=16-byte
+ * alignment never split a line, and the scalar backend stores bytes.
+ * Flat roots are not peeled (D-bit packed cursor); 64-byte-align
+ * output buffers if that case matters to you. */
+#if defined(PIVCO_BACKEND_X86) || defined(PIVCO_BACKEND_AVX512)
+#define PIVCO_ROOT_ALIGN_PEEL 1
+static inline int root_peel_len(const uint8_t *out, int n)
+{
+    if (((uintptr_t)out & 7) != 0) return 0;  /* can't reach a line boundary */
+    int p = PIVCO_MERGE_ALIGN_PEEL(out);
+    return p < n ? p : 0;
+}
+#endif
+
 static void codec_decode_subtree(const pivco_huffman_table_t *table,
                                    int16_t node_id, int K,
                                    uint8_t *out_buf,
@@ -482,10 +514,20 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         /* No K_right header (kr_header_needed returns false). */
         uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
         const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
-        prim_merge_cst_cst(bm, K,
+        int j0 = 0;
+#ifdef PIVCO_ROOT_ALIGN_PEEL
+        if (node_id == table->tree_root) {
+            j0 = root_peel_len(out_buf, K);
+            const uint8_t two[2] = { (uint8_t)table->tree[node->left].symbol,
+                                     (uint8_t)table->tree[node->right].symbol };
+            for (int j = 0; j < j0; j++)
+                out_buf[j] = two[(bm[j >> 3] >> (j & 7)) & 1];
+        }
+#endif
+        prim_merge_cst_cst(bm + (j0 >> 3), K - j0,
                            (uint8_t)table->tree[node->left].symbol,
                            (uint8_t)table->tree[node->right].symbol,
-                           out_buf);
+                           out_buf + j0);
         return;
     }
 
@@ -499,9 +541,22 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
             : scratch_carve(&scratch_top, K_right);
         codec_decode_subtree(table, node->right, K_right,
                               right_buf, in_ptr, scratch_top, g_dec_inplace);
-        prim_merge_cst_vec(bm, K,
+        int j0 = 0, rc0 = 0;
+#ifdef PIVCO_ROOT_ALIGN_PEEL
+        if (node_id == table->tree_root && K_right >= 64) {
+            j0 = root_peel_len(out_buf, K);
+            const uint8_t lsym = (uint8_t)table->tree[node->left].symbol;
+            for (int j = 0; j < j0; j++) {
+                int mb = (bm[j >> 3] >> (j & 7)) & 1;
+                uint8_t rv = right_buf[rc0];
+                out_buf[j] = mb ? rv : lsym;
+                rc0 += mb;
+            }
+        }
+#endif
+        prim_merge_cst_vec(bm + (j0 >> 3), K - j0,
                            (uint8_t)table->tree[node->left].symbol,
-                           right_buf, out_buf);
+                           right_buf + rc0, out_buf + j0);
         return;
     }
 
@@ -534,7 +589,20 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
                               left_buf,  in_ptr, scratch_top, g_dec_inplace);
         codec_decode_subtree(table, node->right, K_right,
                               right_buf, in_ptr, scratch_top, g_dec_inplace);
-        prim_merge_vec_vec(bm, K, left_buf, right_buf, out_buf);
+        int j0 = 0, rc0 = 0, lc0 = 0;
+#ifdef PIVCO_ROOT_ALIGN_PEEL
+        if (node_id == table->tree_root && K_right >= 64 && K_left >= 64) {
+            j0 = root_peel_len(out_buf, K);
+            for (int j = 0; j < j0; j++) {
+                int mb = (bm[j >> 3] >> (j & 7)) & 1;
+                uint8_t rv = right_buf[rc0], lv = left_buf[lc0];
+                out_buf[j] = mb ? rv : lv;
+                rc0 += mb; lc0 += 1 - mb;
+            }
+        }
+#endif
+        prim_merge_vec_vec(bm + (j0 >> 3), K - j0,
+                           left_buf + lc0, right_buf + rc0, out_buf + j0);
         return;
     }
     }
@@ -575,10 +643,20 @@ int CODEC_DECODE_ENTRY(const uint8_t *in, size_t in_len,
         const uint8_t *bm = wire_read_bitmap(&ptr, N, bm_scratch);
         const pivco_tree_node_t *left_child  = &table->tree[root->left];
         const pivco_tree_node_t *right_child = &table->tree[root->right];
-        prim_merge_cst_cst(bm, N,
+        int j0 = 0;
+#ifdef PIVCO_ROOT_ALIGN_PEEL
+        j0 = root_peel_len(symbols, N);
+        if (j0) {
+            const uint8_t two[2] = { (uint8_t)left_child->symbol,
+                                     (uint8_t)right_child->symbol };
+            for (int j = 0; j < j0; j++)
+                symbols[j] = two[(bm[j >> 3] >> (j & 7)) & 1];
+        }
+#endif
+        prim_merge_cst_cst(bm + (j0 >> 3), N - j0,
                                (uint8_t)left_child->symbol,
                                (uint8_t)right_child->symbol,
-                               symbols);
+                               symbols + j0);
         *consumed = (size_t)(ptr - in);
         return PIVCO_OK;
     }

--- a/src/pivco_huffman_common.h
+++ b/src/pivco_huffman_common.h
@@ -4,6 +4,31 @@
 #include "pivco_huffman.h"
 #include <string.h>
 
+/* ---------- Merge store-alignment head-peel ----------
+ *
+ * The SIMD merge kernels stream wide unaligned stores into `out`.  When
+ * `out` is not cache-line-aligned every one of those stores splits a
+ * line, at ~2 cycles a store on big x86 cores — for a block-sized run
+ * that is a 13-16% decode tax whenever the caller's output buffer isn't
+ * 64-byte-aligned.  malloc guarantees only 16, so heap-allocated output
+ * buffers lose this coin toss 3 times out of 4 (the "allocation
+ * lottery"; ping-pong-results results/exp_alloc7-summary).
+ *
+ * Fix: the codec peels the first (-out & 63) symbols of the ROOT merge
+ * (the only merge that writes caller memory — interior merges write
+ * layout-fixed arena regions) so the kernel's stores start on a line
+ * boundary.  See the root-merge peel block in pivco_huffman_codec.c.
+ * The peel is rounded down to a multiple of 8 to keep the bitmap
+ * handoff byte-aligned; for 8-byte-aligned outputs (any real
+ * allocator) that still reaches the full 64-byte boundary.
+ *
+ * x86 backends only.  NEON's 8/16-byte stores at the >=16-byte
+ * alignment every real allocator provides never cross a line, so ARM
+ * is untouched (its separate hazard is load-side page splits —
+ * issue #8). */
+#define PIVCO_MERGE_ALIGN_PEEL(out_ptr) \
+    ((int)((0 - (uintptr_t)(out_ptr)) & 63) & ~7)
+
 /* ---------- Bitmap utilities ---------- */
 
 /* Popcount of a bitmap stored as bytes. n_bytes = ceil(count / 8). */


### PR DESCRIPTION
I ran into a roughly 15% slowdown on proba80/calgary due to heap layout. It seemed to be a ~1000 cycle/32K chunk penalty, possibly attributed to ~12-20 **ld_blocks.address_alias** performance counter events per 32K chunk.

In AVX-512, when merging into an unaligned buffer, every store crosses a cache line. Similarly when reading from the unaligned merge input streams 63/64, i.e. 98.5% of stores cross a cache line. This is generally fine, as modern hardware supports unaligned loads and stores well. But in this case, it seems the unaligned stores to the output are hurting.

The counter leads me to guessing that part of the problem is something like 64K-aliasing: buffers within our scratch space aren't far enough apart to alias each other, but Intel's Memory Ordering Buffer (MOB) initially just compares the low bits of the address to identify the hazard. Within our scratch space this could be unambiguous, but with the separately allocated output-buffer, it could alias. The CPU is usually good at recovering from false aliasing in about 5 cycles, so a handful of events shouldn't explain a 1000 cycle delay. However, Intel's manual additionally notes that if the load spans two cache lines, it may be delayed until the conflicting store is committed to cache, which is the inverse of what we're fixing (loads instead of stores), but hints that cache-line-crossing, which we're absolutely hammering, is an additional hazard to efficiently resolving false aliasing.

All these theories could use more evidence and experiments, but hopefully this is enough for others to reproduce and mitigate the hazard.

Fable eventually traced the inconsistency to being caused by the output buffer's alignment. The allocator generally returns 16-byte aligned pointers, which is plenty for SSE2/NEON, but not for AVX2 or AVX-512 alignment.

I'm sharing Fable's fix so that hopefully you don't need to waste as much time as I did on it.

```
  ┌─────────────────────┬───────┬───────┬───────┬───────┐
  │    dec_buf phase    │   0   │  16   │  32   │  48   │
  ├─────────────────────┼───────┼───────┼───────┼───────┤
  │ main plain, proba80 │ 19326 │ 16234 │ 16240 │ 16223 │
  ├─────────────────────┼───────┼───────┼───────┼───────┤
  │ main fixed          │ 19199 │ 18513 │ 18706 │ 18952 │
  ├─────────────────────┼───────┼───────┼───────┼───────┤
  │ main plain, calgary │ 14820 │ 13014 │ 13014 │ 13068 │
  ├─────────────────────┼───────┼───────┼───────┼───────┤
  │ main fixed          │ 14774 │ 14187 │ 14308 │ 14373 │
  └─────────────────────┴───────┴───────┴───────┴───────┘
```

I suspect a better fix could use an initial, unaligned AVX-512 store, overlapped. And I'm not sure why the penalty only shrunk from ~16% to ~4%, more investigation needed, but I figured this was worth sharing.