### PR TITLE
Ping-pong scratch allocation + decode-order wire format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ cmake --build build
 - **Backends**: scalar, NEON (ARM), x86 (SSE4.1 / AVX2), AVX-512 VBMI2 (Intel).  SVE is disabled (svcompact at 128-bit isn't competitive with NEON TBL).
 - **Codec framework**: one `pivco_huffman_codec.c` compiled per backend as an OBJECT library, each pulling in `primitives_<backend>.h` (the only file with SIMD intrinsics).  Runtime dispatcher in `src/pivco_huffman.c::resolve_impl` picks the best backend per host.
 - **Block size**: 8192 (ARM/AVX-512), 4096 (x86 SSE/AVX2) — auto-detected per backend at compile time
-- **Wire format**: see `src/pivco_huffman_wire.h` for the canonical doc.  Post-order records: `[optional K_right:u16 LE at node entry][children's regions][FSE marker:u8][bitmap or FSE payload]` — each bitmap sits where its merge consumes it.  Flat subtrees (D ≥ 2) skip the header and emit one N·D-bit packed region.
+- **Wire format**: see `src/pivco_huffman_wire.h` for the canonical doc.  Post-order records: `[optional K_right:u16 LE at node entry][children's regions, larger-K child first][FSE marker:u8][bitmap or FSE payload]` — each bitmap sits where its merge consumes it.  Flat subtrees (D ≥ 2) skip the header and emit one N·D-bit packed region.
 - **Key data structures**:
   - `compress_tab[256][32]` combined shuffle table (TBL/pshufb partition; per-arch in `pivco_huffman_{neon,x86}_tables.c`)
   - `expand_tab[256][8]` BU tree_merge shuffle table (same files)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ cmake --build build
 - **Backends**: scalar, NEON (ARM), x86 (SSE4.1 / AVX2), AVX-512 VBMI2 (Intel).  SVE is disabled (svcompact at 128-bit isn't competitive with NEON TBL).
 - **Codec framework**: one `pivco_huffman_codec.c` compiled per backend as an OBJECT library, each pulling in `primitives_<backend>.h` (the only file with SIMD intrinsics).  Runtime dispatcher in `src/pivco_huffman.c::resolve_impl` picks the best backend per host.
 - **Block size**: 8192 (ARM/AVX-512), 4096 (x86 SSE/AVX2) — auto-detected per backend at compile time
-- **Wire format**: see `src/pivco_huffman_wire.h` for the canonical doc.  Per-node record: `[optional K_right:u16 LE][FSE marker:u8][bitmap or FSE payload]`.  Flat subtrees (D ≥ 2) skip the header and emit one N·D-bit packed region.
+- **Wire format**: see `src/pivco_huffman_wire.h` for the canonical doc.  Post-order records: `[optional K_right:u16 LE at node entry][children's regions][FSE marker:u8][bitmap or FSE payload]` — each bitmap sits where its merge consumes it.  Flat subtrees (D ≥ 2) skip the header and emit one N·D-bit packed region.
 - **Key data structures**:
   - `compress_tab[256][32]` combined shuffle table (TBL/pshufb partition; per-arch in `pivco_huffman_{neon,x86}_tables.c`)
   - `expand_tab[256][8]` BU tree_merge shuffle table (same files)

--- a/include/pivcohuf_file.h
+++ b/include/pivcohuf_file.h
@@ -59,7 +59,7 @@ extern "C" {
 
 #define PIVCOHUF_MAGIC          "PIVCOHUF"
 #define PIVCOHUF_VERSION_MAJOR  0
-#define PIVCOHUF_VERSION_MINOR  7
+#define PIVCOHUF_VERSION_MINOR  8
 #define PIVCOHUF_HEADER_SIZE    26
 
 typedef enum {

--- a/include/pivcohuf_file.h
+++ b/include/pivcohuf_file.h
@@ -1,12 +1,12 @@
-/* pivcohuf file format (v0.3) -- standalone file-level codec built on
+/* pivcohuf file format -- standalone file-level codec built on
  * top of the pivco-huffman block primitives.
  *
  *   WIRE FORMAT (little-endian throughout)
  *
  *   HEADER (26 bytes, fixed across versions)
  *      0-7   "PIVCOHUF" magic
- *      8     MAJOR_VERSION (0)
- *      9     MINOR_VERSION (3)
+ *      8     MAJOR_VERSION (PIVCOHUF_VERSION_MAJOR below)
+ *      9     MINOR_VERSION (PIVCOHUF_VERSION_MINOR below)
  *     10-17  BODY_LENGTH (uint64) -- length of BODY in bytes
  *     18-21  BODY_CHECKSUM (XXH32 of BODY bytes, seed 0)
  *     22-25  HEADER_CHECKSUM (XXH32 of bytes 0..21, seed 0)
@@ -59,8 +59,7 @@ extern "C" {
 
 #define PIVCOHUF_MAGIC          "PIVCOHUF"
 #define PIVCOHUF_VERSION_MAJOR  0
-#define PIVCOHUF_VERSION_MINOR  6  /* 0.5: uint16 block_N header (shipped unversioned);
-                                    * 0.6: FSE wide-cursor path, any bitmap length */
+#define PIVCOHUF_VERSION_MINOR  7
 #define PIVCOHUF_HEADER_SIZE    26
 
 typedef enum {

--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -220,12 +220,21 @@ extern uint64_t g_pivco_fse_bytes_out[PIVCO_FSE_STATS_SLOTS];
 
 /* ---------- Encode tree walk ---------- *
  *
- * DFS, pre-order: emit the partition bitmap at this node, then recurse left,
- * then right.  At each non-flat internal node, `ranks[0..n)` holds the
- * surviving leaves' in-order ranks; partition routes each by `rank >
- * split_rank[node]`, leaving the left half in place in `ranks[0..n_left)` and
- * compacting the right half into `tmp[0..n_right)`.  The recursion descends
- * left on `ranks`, right on `tmp`. */
+ * DFS, emitting records in decompression order (an Euler walk): the
+ * partition runs at node entry (it routes the ranks the recursion
+ * needs) and the K_right header is written there too, but the node's
+ * marker+bitmap record is emitted after the children's regions —
+ * exactly where the decoder's merge consumes it, so the decoder reads
+ * the stream strictly forward.  At each non-flat internal node,
+ * `ranks[0..n)` holds the surviving leaves' in-order ranks; partition
+ * routes each by `rank > split_rank[node]`, leaving the left half in
+ * place in `ranks[0..n_left)` and compacting the right half into
+ * `tmp[0..n_right)`.  The recursion descends left on `ranks`, right on
+ * `tmp`.  The bitmap is staged in a stack buffer across the recursion
+ * (its final stream position depends on the children's — FSE-variable —
+ * encoded sizes, so it can't be written in place up front);
+ * ≤ bitmap_bytes(N)+64 per level, tree height ≤ PIVCO_MAX_CODE_LEN
+ * levels. */
 
 /* Arch-agnostic FSE attempt on a freshly-built raw bitmap.
  *
@@ -334,21 +343,16 @@ static void codec_encode_node(const pivco_huffman_table_t *table,
         return;
     }
 
-    /* Non-flat internal node.  codec.c owns: K_right header reservation,
-     * FSE marker byte, optional FSE-attempt on the raw bitmap.  The
-     * arch-specific primitive does only the SIMD-bound work: build the
-     * raw bitmap and partition codes_la. */
-    uint8_t *kr_slot = wire_reserve_kr_header(table, node_id, out_ptr);
-
-    /* Reserve marker (default = 0, raw bitmap). */
-    uint8_t *marker_slot = *out_ptr;
-    *marker_slot = 0;
-    *out_ptr += 1;
-
-    /* Reserve the bitmap region; primitive fills it in. */
+    /* Non-flat internal node.  codec.c owns: K_right header, FSE marker
+     * byte, optional FSE-attempt on the raw bitmap.  The arch-specific
+     * primitive does only the SIMD-bound work: build the raw bitmap and
+     * partition the ranks.
+     *
+     * The bitmap is built into a stack staging buffer (+64 slack
+     * absorbs the SIMD partitions' over-wide tail stores) and copied
+     * into the stream after the children's regions. */
     int nbytes = bitmap_bytes(n);
-    uint8_t *bm = *out_ptr;
-    *out_ptr += nbytes;
+    uint8_t bm_stage[(size_t)nbytes + 64];
 
     /* Pick the partition variant by node_type, mirroring the decode-side
      * dispatch.  The bitmap (and thus the wire bytes) is identical across
@@ -361,28 +365,36 @@ static void codec_encode_node(const pivco_huffman_table_t *table,
     PROF_TIC();
     switch ((pivco_node_type_t)table->node_type[node_id]) {
     case PIVCO_NODE_BOTH_LEAVES:
-        n_right = prim_enc_partition_none(ranks, n, thr, bm);        break;
+        n_right = prim_enc_partition_none(ranks, n, thr, bm_stage);        break;
     case PIVCO_NODE_LEAF_LEFT:
-        n_right = prim_enc_partition_right(ranks, n, thr, bm, tmp);  break;
+        n_right = prim_enc_partition_right(ranks, n, thr, bm_stage, tmp);  break;
     default:
-        n_right = prim_enc_partition_full(ranks, n, thr, bm, tmp);   break;
+        n_right = prim_enc_partition_full(ranks, n, thr, bm_stage, tmp);   break;
     }
     PROF_TOC(PROF_ENC_NODE_FULL, n);
     int n_left  = n - n_right;
 
-    /* Optional FSE attempt on the raw bitmap.  On commit, marker_slot
-     * and bm region are rewritten in place and *out_ptr is advanced to
-     * the end of the FSE payload (which may be shorter than the raw
-     * bitmap region we already reserved).  No-op otherwise. */
-    codec_maybe_fse_attempt(marker_slot, bm, nbytes,
-                             n, n_left, n_right, depth, out_ptr);
-
-    wire_commit_kr_header(kr_slot, n_right);
+    /* One K_right header per recursion site, consumed by the decoder
+     * at node entry so it can size both children before their regions
+     * arrive. */
+    wire_write_kr_header(table, node_id, out_ptr, n_right);
 
     codec_encode_node(table, node->left,  ranks, n_left,  depth + 1,
                        out_ptr, tmp + n_right);
     codec_encode_node(table, node->right, tmp,   n_right, depth + 1,
                        out_ptr, tmp + n_right);
+
+    /* Emit this node's record: marker + staged bitmap.  The FSE attempt
+     * may rewrite marker+bm in place with [fse_len][payload] and pull
+     * *out_ptr back to the payload end.  No-op otherwise. */
+    uint8_t *marker_slot = *out_ptr;
+    *marker_slot = 0;
+    *out_ptr += 1;
+    uint8_t *bm = *out_ptr;
+    memcpy(bm, bm_stage, (size_t)nbytes);
+    *out_ptr += nbytes;
+    codec_maybe_fse_attempt(marker_slot, bm, nbytes,
+                             n, n_left, n_right, depth, out_ptr);
 }
 
 int CODEC_ENCODE_ENTRY(const uint8_t *symbols, size_t n,
@@ -429,6 +441,13 @@ int CODEC_ENCODE_ENTRY(const uint8_t *symbols, size_t n,
  * output buffer.  Internal nodes recurse into their children (which
  * write to scratch arenas), then merge per the bitmap.  The flat-
  * subtree fast path bypasses recursion entirely.
+ *
+ * The wire is in decompression order, so the input cursor is consumed
+ * strictly forward and each record is loaded exactly where it is
+ * used: the K_right header at node entry, the children's regions
+ * during their recursion, the node's bitmap right before its merge.
+ * The bm_scratch VLA for FSE-coded bitmaps is thus also allocated
+ * after the recursion, so its lifetime doesn't span the subtree.
  *
  * Dispatch on node_type, computed at build-table time (by children's
  * leafness — a leaf child's symbol goes straight into the parent's
@@ -490,15 +509,19 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
     }
 
     case PIVCO_NODE_LEAF_LEFT: {
+        /* K_right header at entry sizes the right child; recurse right;
+         * then the [marker][bitmap] record — which the merge consumes —
+         * is read right before the merge (post-order). */
         int K_right = wire_read_kr_header(table, node_id, in_ptr);
-        uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
-        const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
 
         uint8_t *right_buf = tail_ok
             ? place_tail(out_buf, K - K_right, K_right, &scratch_top)
             : scratch_carve(&scratch_top, K_right);
         codec_decode_subtree(table, node->right, K_right,
                               right_buf, in_ptr, scratch_top, g_dec_inplace);
+
+        uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
+        const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
         prim_merge_cst_vec(bm, K,
                            (uint8_t)table->tree[node->left].symbol,
                            right_buf, out_buf);
@@ -507,11 +530,11 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
 
     case PIVCO_NODE_INTERNAL_FULL:
     default: {
-        /* Both children internal.  Recurse into both with disjoint
-         * scratch slices, then merge. */
+        /* Both children internal.  The K_right header at entry sizes
+         * both children so the recursion can carve disjoint scratch
+         * slices; the bitmap is read after both children decode, right
+         * before the merge (post-order). */
         int K_right = wire_read_kr_header(table, node_id, in_ptr);
-        uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
-        const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
 
         int K_left = K - K_right;
         uint8_t *left_buf, *right_buf;
@@ -534,6 +557,9 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
                               left_buf,  in_ptr, scratch_top, g_dec_inplace);
         codec_decode_subtree(table, node->right, K_right,
                               right_buf, in_ptr, scratch_top, g_dec_inplace);
+
+        uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
+        const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
         prim_merge_vec_vec(bm, K, left_buf, right_buf, out_buf);
         return;
     }

--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -50,109 +50,13 @@ static uint8_t *decode_scratch_ensure(size_t need)
     return g_decode_scratch;
 }
 
-/* ---------- Runtime placement flags (issue #10 integration) ----------
- *
- * PIVCO_DEC_CARVE=1    page-hazard-aware scratch carving: child slices
- *                      are nudged off page boundaries (issue #8's
- *                      split-load penalty on a parked merge cursor).
- * PIVCO_DEC_INPLACE=1  in-place merge: an internal node's longer child
- *                      decodes into out_buf's tail instead of scratch,
- *                      halving the merge working set.
- *
- * Both default OFF: placement is then byte-identical to the plain bump
- * allocator.  Read once per process (per backend TU). */
-static int g_dec_carve   = -1;
-static int g_dec_inplace = -1;
-static inline int dec_flag(const char *name, int *cache)
-{
-    int v = *cache;
-    if (v < 0) {
-        const char *e = getenv(name);
-        v = (e && e[0] == '1');
-        *cache = v;
-    }
-    return v;
-}
-
-/* SCRATCH_PAGE is the page-split-load hazard granularity used by
- * scratch_carve below: the hardware page size (16 KB Apple Silicon,
- * 4 KB elsewhere in the fleet; a 64 KB-page Linux arm64 kernel gets
- * needless-but-harmless 4 KB padding). */
-#if defined(__APPLE__) && defined(__aarch64__)
-#define SCRATCH_PAGE   ((uintptr_t)16384)
-#else
-#define SCRATCH_PAGE   ((uintptr_t)4096)
-#endif
-#define MERGE_OVERREAD ((uintptr_t)PIVCO_PRIM_MERGE_OVERREAD)
-/* Keep the first ~cache line of every slice straddle-free: a merge
- * cursor lingers NEAR offset 0 (not just at it) while the other side
- * drains. */
-#define START_GUARD    ((uintptr_t)64)
-
-/* ALL padding draws from a per-block budget (reset in the decode
- * entry): when it runs out, slices are placed unpadded -- a perf
- * hazard reachable only by adversarial page phases, never a safety
- * issue.  Absolute (not per-page) so the arena bound is identical on
- * every platform. */
-#define PIVCO_SCRATCH_PAD_BUDGET ((size_t)16384)
-static __thread size_t g_scratch_pad_left;
-
-/* Carve a child slice off the arena.  With PIVCO_DEC_CARVE off this is
- * a plain bump.  With it on, page-hazard-aware placement (issue #8):
- *   - sub-page slice: never crosses a page boundary (its cursor dwells
- *     everywhere inside it, so a mid-slice straddle is the hammer);
- *   - page-crossing slice: interior straddles are unavoidable (and its
- *     cursor moves fast anyway); small nudges keep the START zone and
- *     the exhausted-cursor END position straddle-free (the end lands ON
- *     a boundary, so the end-position load reads the next page without
- *     straddling). */
-static inline uint8_t *scratch_carve(uint8_t **top, int size)
-{
-    uintptr_t p = (uintptr_t)*top;
-    if (g_dec_carve) {
-        uintptr_t rem = SCRATCH_PAGE - (p & (SCRATCH_PAGE - 1));  /* 1..PAGE */
-        uintptr_t pad = 0;
-        if ((uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE) {
-            if ((uintptr_t)size + MERGE_OVERREAD > rem)
-                pad = rem;                              /* sub-page: never cross */
-        } else {
-            if (rem < START_GUARD) pad = rem;           /* clean start */
-            uintptr_t end  = p + pad + (uintptr_t)size;
-            uintptr_t erem = SCRATCH_PAGE - (end & (SCRATCH_PAGE - 1));
-            if (erem < MERGE_OVERREAD) {
-                pad += erem;                            /* end onto boundary */
-                uintptr_t srem = SCRATCH_PAGE - ((p + pad) & (SCRATCH_PAGE - 1));
-                if (srem < START_GUARD) pad += srem;    /* re-clean start */
-            }
-        }
-        if (pad <= g_scratch_pad_left) g_scratch_pad_left -= pad; else pad = 0;
-        p += pad;
-    }
-    *top = (uint8_t *)(p + (uintptr_t)size);
-    return (uint8_t *)p;
-}
-
-/* Place an internal node's tail child at out_buf + offset (in-place
- * merge; only called when tail_ok && PIVCO_DEC_INPLACE).  A tail's
- * position is fixed by the merge invariant, so it cannot be nudged;
- * the one dangerous placement is a SUB-PAGE tail that would cross a
- * page boundary (a small slice's cursor is parked everywhere in it) --
- * that one falls back to a no-cross carve, charging the extra scratch
- * content to the same pad budget. */
-static inline uint8_t *place_tail(uint8_t *out_buf, int offset, int size,
-                                  uint8_t **top)
-{
-    uint8_t *p = out_buf + offset;
-    if (g_dec_carve && (uintptr_t)size + MERGE_OVERREAD <= SCRATCH_PAGE) {
-        uintptr_t rem = SCRATCH_PAGE - ((uintptr_t)p & (SCRATCH_PAGE - 1));
-        if ((uintptr_t)size + MERGE_OVERREAD > rem &&
-            (size_t)size <= g_scratch_pad_left) {
-            g_scratch_pad_left -= (size_t)size;   /* charge the content... */
-            return scratch_carve(top, size);      /* ...the carve pads itself */
-        }
-    }
-    return p;
-}
+/* MERGE_OVERREAD: the SIMD merges load their source buffers in
+ * full-vector chunks, so they may read (never write) up to this many
+ * bytes past a source's end.  Every buffer the decode walk hands to a
+ * merge therefore needs this much trailing slack inside the arena; the
+ * caller's `symbols` buffer, which guarantees none, is only ever a
+ * merge destination (writes are exact). */
+#define MERGE_OVERREAD ((size_t)PIVCO_PRIM_MERGE_OVERREAD)
 
 /* Thread-local growable encode scratch arena.  Mirrors the decode arena
  * above: holds the per-block ranks buffer + the tree-walk's right-half
@@ -450,44 +354,51 @@ int CODEC_ENCODE_ENTRY(const uint8_t *symbols, size_t n,
     return PIVCO_OK;
 }
 
-/* ---------- Bottom-up decode tree walk ---------- *
+/* ---------- Bottom-up decode tree walk (ping-pong scratch) ---------- *
  *
- * Bottom-up: each call decodes a subtree into a contiguous K-byte
- * output buffer.  Internal nodes recurse into their children (which
- * write to scratch arenas), then merge per the bitmap.  The flat-
- * subtree fast path bypasses recursion entirely.
+ * Each call decodes a subtree's K symbols into out[0,K).  Internal
+ * nodes recurse into their children, then merge per the node's bitmap.
+ * The flat-subtree fast path bypasses recursion entirely.
  *
- * The wire is in decompression order, so the input cursor is consumed
- * strictly forward and each record is loaded exactly where it is
- * used: the K_right header at node entry, the children's regions
- * during their recursion, the node's bitmap right before its merge.
- * The bm_scratch VLA for FSE-coded bitmaps is thus also allocated
- * after the recursion, so its lifetime doesn't span the subtree.
+ * The wire is in decompression order — larger-K child first — so the
+ * input cursor is consumed strictly forward and each record is loaded
+ * exactly where it is used: the K_right header at node entry, the
+ * children's regions during their recursion, the node's bitmap right
+ * before its merge.
+ *
+ * Scratch placement is a two-buffer ping-pong (out, tmp):
+ *
+ *   - the larger child decodes in place into out's tail
+ *     out[K_small, K): safe under the merge, whose write cursor can
+ *     never overtake its tail-side read cursor (by the time it writes
+ *     out[i] it has consumed at least i - K_small tail bytes);
+ *   - the smaller child decodes into tmp[0, K_small), and its own
+ *     recursion uses out's still-empty prefix out[0, K_small) as its
+ *     partner — the pair (tmp, out-prefix) ping-pongs down the
+ *     smaller-child spine.
+ *
+ * The caller guarantees tmp capacity floor(K/2): a node's smaller child
+ * is at most floor(K/2), and everything a smaller child's subtree puts
+ * in its partner stays inside out[0, K_small).  The walk's footprint is
+ * therefore out[0,K), plus at most floor(K/2) bytes past tmp (the
+ * largest smaller-child on the larger-child spine), plus MERGE_OVERREAD
+ * read slack past whichever region ends last.
  *
  * Dispatch on node_type, computed at build-table time (by children's
  * leafness — a leaf child's symbol goes straight into the parent's
  * merge, so the walk never recurses into a leaf):
  *
- *   INTERNAL_FLAT   — packed-bits flat decode into out_buf
+ *   INTERNAL_FLAT   — packed-bits flat decode into out
  *   BOTH_LEAVES     — both children leaves, merge_cst_cst directly
- *   LEAF_LEFT       — left child leaf, recurse right, merge_cst_vec
- *   INTERNAL_FULL   — both children internal: recurse both, merge_vec_vec
- *
- * `scratch_top` is the arena pointer for child output buffers; each
- * caller carves its children's slices off it (see scratch_carve) when
- * calling further down.
- *
- * `tail_ok` is nonzero when out_buf is arena-backed (a carve or a
- * nested tail) and so has MERGE_OVERREAD trailing slack: a child may
- * then be placed in its tail (see place_tail) when PIVCO_DEC_INPLACE
- * is on.  The root call passes 0 -- the caller's output buffer has no
- * over-read slack. */
+ *   LEAF_LEFT       — left child leaf, recurse right (in place, into
+ *                     out's tail), merge_cst_vec
+ *   INTERNAL_FULL   — both children internal: larger child in place,
+ *                     smaller via the ping-pong partner, merge_vec_vec */
 
 static void codec_decode_subtree(const pivco_huffman_table_t *table,
                                    int16_t node_id, int K,
-                                   uint8_t *out_buf,
-                                   const uint8_t **in_ptr,
-                                   uint8_t *scratch_top, int tail_ok)
+                                   uint8_t *out, uint8_t *tmp,
+                                   const uint8_t **in_ptr)
 {
     if (K == 0) return;
 
@@ -508,7 +419,7 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         *in_ptr += total_bytes;
         const uint8_t *c2s =
             &table->flat_code_to_sym[table->flat_offset[node_id]];
-        prim_merge_flat(out_buf, K, bm, D, c2s);
+        prim_merge_flat(out, K, bm, D, c2s);
         return;
     }
 
@@ -519,71 +430,54 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         prim_merge_cst_cst(bm, K,
                            (uint8_t)table->tree[node->left].symbol,
                            (uint8_t)table->tree[node->right].symbol,
-                           out_buf);
+                           out);
         return;
     }
 
     case PIVCO_NODE_LEAF_LEFT: {
-        /* K_right header at entry sizes the right child; recurse right;
-         * then the [marker][bitmap] record — which the merge consumes —
-         * is read right before the merge (post-order). */
+        /* One internal child (right); the leaf contributes the K_left
+         * symbols the merge fills into out's prefix.  The right child
+         * decodes in place into out's tail, whatever its share of K. */
         int K_right = wire_read_kr_header(table, node_id, in_ptr);
-
-        uint8_t *right_buf = tail_ok
-            ? place_tail(out_buf, K - K_right, K_right, &scratch_top)
-            : scratch_carve(&scratch_top, K_right);
+        uint8_t *right_buf = out + (K - K_right);
         codec_decode_subtree(table, node->right, K_right,
-                              right_buf, in_ptr, scratch_top, g_dec_inplace);
+                              right_buf, tmp, in_ptr);
 
         uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
         const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
         prim_merge_cst_vec(bm, K,
                            (uint8_t)table->tree[node->left].symbol,
-                           right_buf, out_buf);
+                           right_buf, out);
         return;
     }
 
     case PIVCO_NODE_INTERNAL_FULL:
     default: {
-        /* Both children internal.  The K_right header at entry sizes
-         * both children so the recursion can carve disjoint scratch
-         * slices; the bitmap is read after both children decode, right
-         * before the merge (post-order). */
+        /* Both children internal.  Stream order == decode order ==
+         * larger first (strict >, ties left-first — must match the
+         * encoder). */
         int K_right = wire_read_kr_header(table, node_id, in_ptr);
-
-        int K_left = K - K_right;
+        int K_left  = K - K_right;
         uint8_t *left_buf, *right_buf;
-        if (tail_ok && K_left >= K_right) {
-            /* Longer child decodes into out_buf's tail (free -- see
-             * place_tail), the shorter into a scratch carve. */
-            left_buf  = place_tail(out_buf, K_right, K_left, &scratch_top);
-            right_buf = scratch_carve(&scratch_top, K_right);
-        } else if (tail_ok) {
-            right_buf = place_tail(out_buf, K_left, K_right, &scratch_top);
-            left_buf  = scratch_carve(&scratch_top, K_left);
-        } else {
-            left_buf  = scratch_carve(&scratch_top, K_left);
-            right_buf = scratch_carve(&scratch_top, K_right);
-        }
-
-        /* The encoder emits the larger-K child's region first (strict
-         * >, ties left-first); decode order must match the stream.
-         * Buffer placement above is order-independent. */
         if (K_right > K_left) {
+            right_buf = out + K_left;            /* larger, in place    */
+            left_buf  = tmp;                     /* smaller, ping-pong  */
             codec_decode_subtree(table, node->right, K_right,
-                                  right_buf, in_ptr, scratch_top, g_dec_inplace);
+                                  right_buf, tmp, in_ptr);
             codec_decode_subtree(table, node->left,  K_left,
-                                  left_buf,  in_ptr, scratch_top, g_dec_inplace);
+                                  left_buf,  out, in_ptr);
         } else {
+            left_buf  = out + K_right;           /* larger, in place    */
+            right_buf = tmp;                     /* smaller, ping-pong  */
             codec_decode_subtree(table, node->left,  K_left,
-                                  left_buf,  in_ptr, scratch_top, g_dec_inplace);
+                                  left_buf,  tmp, in_ptr);
             codec_decode_subtree(table, node->right, K_right,
-                                  right_buf, in_ptr, scratch_top, g_dec_inplace);
+                                  right_buf, out, in_ptr);
         }
 
         uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
         const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);
-        prim_merge_vec_vec(bm, K, left_buf, right_buf, out_buf);
+        prim_merge_vec_vec(bm, K, left_buf, right_buf, out);
         return;
     }
     }
@@ -632,24 +526,91 @@ int CODEC_DECODE_ENTRY(const uint8_t *in, size_t in_len,
         return PIVCO_OK;
     }
 
-    /* Scratch arena.  Worst case at a heavily-skewed node, the
-     * partition is one-sided so a single recursion can consume up to
-     * N bytes.  Bounded by (MAX_CODE_LEN+2) * N.  Grown on demand from a
-     * thread-local heap buffer so block size is a runtime parameter.
-     * With carve or in-place placement on, double it for carve-bump
-     * waste and add page + over-read slack (the exact 2N + budget
-     * bound comes with the arena-shrink step). */
-    dec_flag("PIVCO_DEC_CARVE",   &g_dec_carve);
-    dec_flag("PIVCO_DEC_INPLACE", &g_dec_inplace);
-    size_t need = (size_t)N * (PIVCO_MAX_CODE_LEN + 2);
-    if (g_dec_carve || g_dec_inplace)
-        need = 2 * need + SCRATCH_PAGE + MERGE_OVERREAD;
+    /* Flat root: the whole tree is one packed-bits region, decoded
+     * straight into symbols (exact writes, no merge, no scratch). */
+    if ((pivco_node_type_t)table->node_type[table->tree_root]
+        == PIVCO_NODE_INTERNAL_FLAT) {
+        int D = table->flat_depth[table->tree_root];
+        int total_bytes = (N * D + 7) >> 3;
+        const uint8_t *bm = ptr;
+        ptr += total_bytes;
+        prim_merge_flat(symbols, N, bm, D,
+                        &table->flat_code_to_sym[table->flat_offset[table->tree_root]]);
+        *consumed = (size_t)(ptr - in);
+        return PIVCO_OK;
+    }
+
+    /* Remaining root shapes recurse.  The ping-pong walk parks children
+     * in its out buffer's tail and prefix and the merges read their
+     * sources with up-to-MERGE_OVERREAD slack past the end — guarantees
+     * the caller's `symbols` doesn't offer.  So the root's children
+     * decode into the thread-local arena (grown on demand, reused
+     * across blocks) and only the root's own merge, whose writes are
+     * exact, targets `symbols`.
+     *
+     * Arena bound: (MAX_CODE_LEN+2)·N, loose.  The ping-pong walk's
+     * true high-water is under 1.5·N — but only on valid streams, so
+     * that figure is not a safe allocation target.  Against invalid
+     * data (a bitmap popcount disagreeing with the declared child
+     * counts) the floor is 2·N plus kernel-overtouch pad: with splits
+     * bounded (0 <= KR <= K — not currently checked), every recursive
+     * (out, tmp) placement satisfies out + 2K <= 2·N and tmp + K <=
+     * 2·N as arena offsets, which caps hostile cursor excursions too. */
+    size_t need = (size_t)N * (PIVCO_MAX_CODE_LEN + 2) + MERGE_OVERREAD;
+
+    if ((pivco_node_type_t)table->node_type[table->tree_root]
+        == PIVCO_NODE_LEAF_LEFT) {
+        /* One internal child: it decodes at the arena base with the
+         * space after it as ping-pong partner; the cst_vec merge fills
+         * symbols. */
+        int K_right = wire_read_kr_header(table, table->tree_root, &ptr);
+        uint8_t *scratch = decode_scratch_ensure(need);
+        if (!scratch) return PIVCO_ERR_NULL;
+        codec_decode_subtree(table, root->right, K_right,
+                              scratch, scratch + K_right, &ptr);
+
+        uint8_t bm_scratch[(size_t)bitmap_bytes(N) + 16];
+        const uint8_t *bm = wire_read_bitmap(&ptr, N, bm_scratch);
+        prim_merge_cst_vec(bm, N,
+                           (uint8_t)table->tree[root->left].symbol,
+                           scratch, symbols);
+        *consumed = (size_t)(ptr - in);
+        return PIVCO_OK;
+    }
+
+    /* INTERNAL_FULL root — hybrid hole-reuse placement.  Both children
+     * decode into the arena's first N bytes, [larger | smaller], and
+     * the final merge writes symbols.  The larger child (first on the
+     * wire) uses the smaller sibling's still-empty slot as its
+     * ping-pong partner — hole-reuse; when a smaller-child on its spine
+     * outgrows that slot, the partner writes spill past N into fresh
+     * arena.  The smaller root child then decodes into its slot with a
+     * fresh partner beyond N. */
+    int K_right = wire_read_kr_header(table, table->tree_root, &ptr);
+    int K_left  = N - K_right;
     uint8_t *scratch = decode_scratch_ensure(need);
     if (!scratch) return PIVCO_ERR_NULL;
-    g_scratch_pad_left = PIVCO_SCRATCH_PAD_BUDGET;
 
-    codec_decode_subtree(table, table->tree_root, N,
-                          symbols, &ptr, scratch, /*tail_ok=*/0);
+    uint8_t *buf_left, *buf_right;
+    if (K_right > K_left) {                  /* right larger -> first on the wire */
+        buf_right = scratch;
+        buf_left  = scratch + K_right;
+        codec_decode_subtree(table, root->right, K_right,
+                              buf_right, /*tmp=*/buf_left, &ptr);
+        codec_decode_subtree(table, root->left,  K_left,
+                              buf_left,  /*tmp=*/scratch + N, &ptr);
+    } else {
+        buf_left  = scratch;
+        buf_right = scratch + K_left;
+        codec_decode_subtree(table, root->left,  K_left,
+                              buf_left,  /*tmp=*/buf_right, &ptr);
+        codec_decode_subtree(table, root->right, K_right,
+                              buf_right, /*tmp=*/scratch + N, &ptr);
+    }
+
+    uint8_t bm_scratch[(size_t)bitmap_bytes(N) + 16];
+    const uint8_t *bm = wire_read_bitmap(&ptr, N, bm_scratch);
+    prim_merge_vec_vec(bm, N, buf_left, buf_right, symbols);
 
     *consumed = (size_t)(ptr - in);
     return PIVCO_OK;

--- a/src/pivco_huffman_codec.c
+++ b/src/pivco_huffman_codec.c
@@ -379,10 +379,25 @@ static void codec_encode_node(const pivco_huffman_table_t *table,
      * arrive. */
     wire_write_kr_header(table, node_id, out_ptr, n_right);
 
-    codec_encode_node(table, node->left,  ranks, n_left,  depth + 1,
-                       out_ptr, tmp + n_right);
-    codec_encode_node(table, node->right, tmp,   n_right, depth + 1,
-                       out_ptr, tmp + n_right);
+    /* Emit the larger-K child's region first: the decoder can then
+     * decode it into scratch that the smaller, not-yet-decoded
+     * sibling's buffer overlaps (hole-reuse), shrinking the arena
+     * high-water.  The two rank buffers (ranks=left, tmp=right) and
+     * the shared deeper scratch tmp+n_right are mutually disjoint, so
+     * the call order is free.  A leaf child emits nothing, so this
+     * only changes the stream at INTERNAL_FULL nodes — exactly where
+     * the decoder reorders. */
+    if (n_right > n_left) {
+        codec_encode_node(table, node->right, tmp,   n_right, depth + 1,
+                           out_ptr, tmp + n_right);
+        codec_encode_node(table, node->left,  ranks, n_left,  depth + 1,
+                           out_ptr, tmp + n_right);
+    } else {
+        codec_encode_node(table, node->left,  ranks, n_left,  depth + 1,
+                           out_ptr, tmp + n_right);
+        codec_encode_node(table, node->right, tmp,   n_right, depth + 1,
+                           out_ptr, tmp + n_right);
+    }
 
     /* Emit this node's record: marker + staged bitmap.  The FSE attempt
      * may rewrite marker+bm in place with [fse_len][payload] and pull
@@ -540,9 +555,7 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
         uint8_t *left_buf, *right_buf;
         if (tail_ok && K_left >= K_right) {
             /* Longer child decodes into out_buf's tail (free -- see
-             * place_tail), the shorter into a scratch carve.  Decode
-             * order stays left-then-right (the wire is pre-order) --
-             * only buffer placement differs. */
+             * place_tail), the shorter into a scratch carve. */
             left_buf  = place_tail(out_buf, K_right, K_left, &scratch_top);
             right_buf = scratch_carve(&scratch_top, K_right);
         } else if (tail_ok) {
@@ -553,10 +566,20 @@ static void codec_decode_subtree(const pivco_huffman_table_t *table,
             right_buf = scratch_carve(&scratch_top, K_right);
         }
 
-        codec_decode_subtree(table, node->left,  K_left,
-                              left_buf,  in_ptr, scratch_top, g_dec_inplace);
-        codec_decode_subtree(table, node->right, K_right,
-                              right_buf, in_ptr, scratch_top, g_dec_inplace);
+        /* The encoder emits the larger-K child's region first (strict
+         * >, ties left-first); decode order must match the stream.
+         * Buffer placement above is order-independent. */
+        if (K_right > K_left) {
+            codec_decode_subtree(table, node->right, K_right,
+                                  right_buf, in_ptr, scratch_top, g_dec_inplace);
+            codec_decode_subtree(table, node->left,  K_left,
+                                  left_buf,  in_ptr, scratch_top, g_dec_inplace);
+        } else {
+            codec_decode_subtree(table, node->left,  K_left,
+                                  left_buf,  in_ptr, scratch_top, g_dec_inplace);
+            codec_decode_subtree(table, node->right, K_right,
+                                  right_buf, in_ptr, scratch_top, g_dec_inplace);
+        }
 
         uint8_t bm_scratch[(size_t)bitmap_bytes(K) + 16];
         const uint8_t *bm = wire_read_bitmap(in_ptr, K, bm_scratch);

--- a/src/pivco_huffman_common.h
+++ b/src/pivco_huffman_common.h
@@ -82,11 +82,11 @@ static inline int bitmap_bytes(int n)
 
 /* K_right wire-format header decision (2026-05-12).
  *
- * Wire format: at each non-flat internal node whose bitmap is followed by
- * recursion into at least one non-leaf child, the encoder writes a 2-byte
- * little-endian uint16 K_right header immediately before the bitmap.  The
- * BU decoder reads this directly instead of running popcount; the TD
- * decoder skips it (still computes splits inline per stride).
+ * Wire format: at each non-flat internal node that recurses into at
+ * least one non-leaf child, the encoder writes a 2-byte little-endian
+ * uint16 K_right header at node entry.  The BU decoder reads it there
+ * instead of running popcount, and uses it to size both children
+ * before their regions arrive.
  *
  * Condition: node has at least one child that's NOT a leaf.  Encodes the
  * exact set of popcount call sites in the BU decoder.  Both-leaf cases

--- a/src/pivco_huffman_wire.h
+++ b/src/pivco_huffman_wire.h
@@ -6,7 +6,11 @@
  * which led to silent drift (scalar+NEON added the FSE marker byte in
  * 2026-05-13, x86+AVX-512 didn't — broke scalar↔SSE cross-decoding).
  *
- * Wire format (v0.6+; the uint16 block_N header below is the v0.5 addition):
+ * Wire format (v0.7): file data in decompression order.  The layout
+ * is an Euler walk of the tree — each node's K_right split header
+ * lands at its pre-order position (on the way down), its
+ * marker+bitmap record at its post-order position (on the way up,
+ * after its children's regions):
  *
  * Per-block header (once, at the very start of each encoded block):
  *   [block_N: uint16 LE, 2 bytes]                  symbol count N for this
@@ -18,7 +22,9 @@
  *                                                  to PIVCO_BLOCK_SIZE.
  *
  * Per non-flat internal node:
- *   [optional K_right_header: uint16 LE, 2 bytes]   if kr_header_needed()
+ *   [optional K_right: uint16 LE, 2 bytes]         if kr_header_needed();
+ *                                                  at node entry
+ *   [left child region][right child region]        recursively, same layout
  *   [FSE marker byte:        uint8,    1 byte]    always
  *   [bitmap body]                                  marker == 0: raw n-bit
  *                                                  bitmap, ceil(n/8) bytes
@@ -26,8 +32,22 @@
  *                                                  fse_len + fse_len bytes
  *                                                  of FSE-compressed bytes
  *
- * Flat-subtree nodes do NOT use this header — they emit n·D packed bits
- * directly.  See pivco_huffman.h:flat_depth.
+ * This is exactly the order the BU decoder consumes bytes.  It needs
+ * both child counts up front to size the children's buffers — and
+ * forward parsing of variable-size regions requires the sizing
+ * information in prefix position anyway — but it consumes a node's
+ * bitmap only at merge time, after both children are decoded.  So the
+ * stream is read strictly forward, each byte touched once, and the
+ * decoder's L1 working set is a moving window.
+ *
+ * The K_right header occupies one slot per recursion site into a
+ * non-leaf child (kr_header_needed()): leaf-only nodes (BOTH_LEAVES,
+ * LEAF_LEFT's leaf side) carry no count, and empty subtrees (n == 0)
+ * emit nothing at all.
+ *
+ * Flat-subtree nodes do NOT use the per-node record — they emit n·D
+ * packed bits directly (they have no children, so pre- and post-order
+ * coincide).  See pivco_huffman.h:flat_depth.
  *
  * Internal header, not part of the public API.
  */
@@ -69,28 +89,19 @@ static inline int wire_read_block_n(const uint8_t **in_ptr)
     return (int)v;
 }
 
-/* ---------- Encode side: reserve / commit slots ----------
+/* ---------- Encode side: K_right header ----------
  *
- * The encoder reserves the header slot(s) BEFORE knowing n_right, then
- * commits the value afterwards.  Returns pointer to where the K_right
- * uint16 should be written (NULL if no header was reserved). */
-static inline uint8_t *wire_reserve_kr_header(const pivco_huffman_table_t *table,
-                                               int16_t node_id,
-                                               uint8_t **out_ptr)
+ * The encoder's partition runs before anything is emitted for the
+ * node, so the header value is known and written directly at node
+ * entry.  No-op when the node carries no header (kr_header_needed()). */
+static inline void wire_write_kr_header(const pivco_huffman_table_t *table,
+                                         int16_t node_id,
+                                         uint8_t **out_ptr, int n_right)
 {
-    if (!kr_header_needed(table, node_id)) return NULL;
-    uint8_t *slot = *out_ptr;
+    if (!kr_header_needed(table, node_id)) return;
+    (*out_ptr)[0] = (uint8_t)(n_right & 0xFF);
+    (*out_ptr)[1] = (uint8_t)((n_right >> 8) & 0xFF);
     *out_ptr += KR_HEADER_BYTES;
-    return slot;
-}
-
-/* Write the K_right value into a previously-reserved slot.  No-op if
- * `slot` is NULL (header wasn't reserved for this node). */
-static inline void wire_commit_kr_header(uint8_t *slot, int n_right)
-{
-    if (!slot) return;
-    slot[0] = (uint8_t)(n_right & 0xFF);
-    slot[1] = (uint8_t)((n_right >> 8) & 0xFF);
 }
 
 /* Note: the FSE marker byte + bitmap (or FSE payload) is emitted by
@@ -105,9 +116,8 @@ static inline void wire_commit_kr_header(uint8_t *slot, int n_right)
 
 /* ---------- Decode side ---------- */
 
-/* Skip the K_right header bytes, returning the value as an int.  If no
- * header is present for this node, returns -1.  (Top-down decoders
- * don't use the value; bottom-up ones do.) */
+/* Read the K_right header at node entry, returning the value as an
+ * int.  If no header is present for this node, returns -1. */
 static inline int wire_read_kr_header(const pivco_huffman_table_t *table,
                                        int16_t node_id,
                                        const uint8_t **in_ptr)

--- a/src/pivco_huffman_wire.h
+++ b/src/pivco_huffman_wire.h
@@ -6,11 +6,11 @@
  * which led to silent drift (scalar+NEON added the FSE marker byte in
  * 2026-05-13, x86+AVX-512 didn't — broke scalar↔SSE cross-decoding).
  *
- * Wire format (v0.7): file data in decompression order.  The layout
- * is an Euler walk of the tree — each node's K_right split header
- * lands at its pre-order position (on the way down), its
- * marker+bitmap record at its post-order position (on the way up,
- * after its children's regions):
+ * Wire format (v0.8): file data in decompression order, larger-K
+ * child first.  The layout is an Euler walk of the tree — each node's
+ * K_right split header lands at its pre-order position (on the way
+ * down), its marker+bitmap record at its post-order position (on the
+ * way up, after its children's regions):
  *
  * Per-block header (once, at the very start of each encoded block):
  *   [block_N: uint16 LE, 2 bytes]                  symbol count N for this
@@ -24,7 +24,11 @@
  * Per non-flat internal node:
  *   [optional K_right: uint16 LE, 2 bytes]         if kr_header_needed();
  *                                                  at node entry
- *   [left child region][right child region]        recursively, same layout
+ *   [larger-K child region][smaller child region]  recursively, same layout;
+ *                                                  larger first (strict >,
+ *                                                  ties left-first), keyed
+ *                                                  on the K_right header —
+ *                                                  no extra bits
  *   [FSE marker byte:        uint8,    1 byte]    always
  *   [bitmap body]                                  marker == 0: raw n-bit
  *                                                  bitmap, ceil(n/8) bytes
@@ -39,6 +43,14 @@
  * bitmap only at merge time, after both children are decoded.  So the
  * stream is read strictly forward, each byte touched once, and the
  * decoder's L1 working set is a moving window.
+ *
+ * The larger-K child goes first so the decoder meets each node's
+ * dominant half while the smaller sibling's buffer is still empty —
+ * the decoder can overlap the larger child's working scratch with
+ * that hole, which is what lets the scratch arena stay near N (see
+ * the decode tree walk in pivco_huffman_codec.c).  Both sides key the
+ * order on the K_right header already on the wire, so it costs no
+ * bits.
  *
  * The K_right header occupies one slot per recursion site into a
  * non-leaf child (kr_header_needed()): leaf-only nodes (BOTH_LEAVES,


### PR DESCRIPTION
This is two somewhat intertwined cache optimisations. The ping-pong scratch is the parenthetical recursive larger-child-first sibling-space-reuse strategy from #9 (but not touching the actual `out_buf` until the final merge). I'm just pairing this with putting data on the wire in the order the decoder consumes it, to be cache-friendly. This pairs well with 32K chunk size on Apple Silicon, and supersedes #10

---

If we look at the access patterns before, for example on `prose_pride`, we see that input reads jump around, roughly forwards and then backwards over the data, and scratch accesses span roughly `2 * chunk_size`:

<img width="1575" height="1042" alt="prose_pride_32k_plain" src="https://github.com/user-attachments/assets/303a9b29-f703-4697-92c4-41bba8c4d25a" />

---

This PR addresses both. The input reads move forward through the data, and by using a larger-child-first order, we can usually decode in `1.25 * chunk_size`, with a worst-case of `1.5 * chunk_size`:

<img width="1581" height="1057" alt="prose_pride_32k_pp_hybrid" src="https://github.com/user-attachments/assets/51f5c664-e35e-4b17-8bf3-e9fbc4a4cf43" />

I'm hoping the diagrams show that this is a pretty principled change. One input stream, one output stream, and an extremely compact scratch space.

<details>
<summary><b>My previous attempt diagram (#10)</b></summary>

Overly careful not to cross pages, but not as dense, and still chaotic reads:

<img width="1582" height="1055" alt="prose_pride_32k_carve_inplace" src="https://github.com/user-attachments/assets/c5e4adf4-0143-4351-910e-f55f028f041b" />

</details>

---

Tested in PHA mode:

* Decode speed +2–6% geomean. 
* On a realistic Silesia LZ-literals corpus, at 32K chunk size, no file regressed on Sapphire Rapids, Zen 4, or Apple M4.
* Worst regression: −3.0% (proba80 at 16K on Zen 4). dna_fasta also struggles consistently on M4 at around −2.6%.
* No change to compressed data size.

Speedups a little larger in PH mode.

Not that impressive, but not bad for a data layout change – we're not changing any primitives.

I've omitted a follow-up commit to decrease scratch allocation size ([2da8952](https://github.com/dougallj/pivco-huffman/commit/2da895202598b0924acf502abc03634c0e17a97b)), because it led to the #15 hazard, and raised questions about whether we should deliberately align our scratch region on Apple Silicon that I don't yet have answers to.

---

I didn't like the "larger-child first" idea used here at first, because doing the smaller child immediately before the merge is theoretically more likely to have store-to-load forwarding hazards, if the smaller-child is tiny. I think this comes up rarely, though.

No pressure to merge this, there are a lot of other design considerations, this is just one that I felt worked out quite well.