### PR TITLE
fse: wide-cursor path for any bitmap length (kills the mod-8 fallback)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,9 @@ if(BUILD_TESTS)
         test/test_edge_cases.c
     )
     target_link_libraries(pivco_huffman_tests pivco_huffman)
+    # tests reach one internal header (pivco_fse.h) for the direct FSE
+    # length-sweep roundtrip
+    target_include_directories(pivco_huffman_tests PRIVATE src)
 endif()
 
 # Benchmarks

--- a/include/pivcohuf_file.h
+++ b/include/pivcohuf_file.h
@@ -30,6 +30,18 @@
  *   value), so nothing beyond the lengths is transmitted.  v0.3 streams are
  *   not readable by v0.4 decoders.
  *
+ *   v0.5: per-block uint16 N header for arbitrary block sizes (see
+ *   pivco_huffman_wire.h).  This wire change actually shipped on main
+ *   without a MINOR bump; it is recorded here so the version line is
+ *   honest, and 0.5 is folded into the 0.6 gate below rather than
+ *   emitted on its own.
+ *
+ *   v0.6 vs v0.4/0.5: the FSE (PHA) bitmap path now uses the wide 8-cursor
+ *   format for any bitmap length, not just multiples of 8.  Streams with
+ *   n % 8 == 0 bitmaps are byte-identical to the prior format; those with
+ *   unaligned FSE bitmaps switch format, so earlier decoders mis-decode
+ *   unaligned FSE streams -- hence the minor bump.
+ *
  *   The final block may have fewer than BLOCK_SIZE input symbols.  The
  *   encoder pads the input to BLOCK_SIZE with the file's first byte
  *   (always present in the alphabet); the decoder truncates output
@@ -47,7 +59,8 @@ extern "C" {
 
 #define PIVCOHUF_MAGIC          "PIVCOHUF"
 #define PIVCOHUF_VERSION_MAJOR  0
-#define PIVCOHUF_VERSION_MINOR  4  /* 0.4: dropped within-tier ordering */
+#define PIVCOHUF_VERSION_MINOR  6  /* 0.5: uint16 block_N header (shipped unversioned);
+                                    * 0.6: FSE wide-cursor path, any bitmap length */
 #define PIVCOHUF_HEADER_SIZE    26
 
 typedef enum {

--- a/src/fse_xy_codec.h
+++ b/src/fse_xy_codec.h
@@ -17,23 +17,54 @@ static size_t encode_x(int x, const uint8_t *src, size_t n,
                        const FSE_CTable *ct)
 {
     if (x < 2 || x > 16) return 0;
-    if (n % (size_t)x != 0) return 0;   /* bench restriction */
+    if (n < (size_t)x) return 0;   /* need one symbol per cursor */
 
     BIT_CStream_t bitC;
     if (FSE_isError(BIT_initCStream(&bitC, dst, dst_cap))) return 0;
 
     FSE_CState_t st[16];
+    /* Any-length form (the old n % x == 0 restriction was a bench-era
+     * shortcut that cost every unaligned bitmap the wide path).  The
+     * decoder assigns position p to cursor p % x round-robin, including
+     * its partial final round, so the encoder walks positions in exact
+     * reverse decode order with the SAME mapping: the highest x
+     * positions are each cursor's last-decoded symbol and are absorbed
+     * into that cursor's initial state (writes no bits); every earlier
+     * position is a real encode.  For n % x == 0 this degenerates to
+     * the classic per-round order bit-for-bit, so previously-valid
+     * streams are unchanged. */
     size_t i = n;
-    for (int k = x - 1; k >= 0; k--) {
-        FSE_initCState2(&st[k], ct, src[--i]);
+    for (int j = 0; j < x; j++) {
+        --i;
+        FSE_initCState2(&st[i % (size_t)x], ct, src[i]);
     }
 
     /* Flush after at most 4 symbols: at tableLog 12 each FSE_encodeSymbol
      * adds up to 12 bits, and a flush leaves up to 7 bits in the 64-bit
      * container, so 7 + 4*12 = 55 <= 64 is safe but 7 + 5*12 = 67 would
      * overflow and silently drop bits (corrupts high-nbBits runs).  This
-     * matches FSE's own 4-symbols-between-flushes bound and the decoder's
-     * reload-every-4 cadence (D8RND). */
+     * matches FSE's own 4-symbols-between-flushes bound; the decoder's
+     * reload cadence is independent (bits are a continuous stream). */
+    /* i == n - x here.  Encode the remaining positions [0, i) in strictly
+     * decreasing order, cursor = pos % x -- the same operation sequence the
+     * flat loop produces, so the emitted bitstream is bit-identical (flush
+     * cadence doesn't change the bits).  Structured for speed: peel the
+     * (i % x) positions above the nearest x-aligned boundary with the
+     * general form, then run fully-unrolled x-wide rounds where the cursor
+     * IS the loop counter (no per-symbol modulo, inner loop unrolls at the
+     * constant x) -- this is the old aligned fast path, restored. */
+    int pk = 0;
+    size_t peel = i % (size_t)x;              /* == n % x; 0 for aligned n */
+    for (size_t p = 0; p < peel; p++) {
+        --i;
+        FSE_encodeSymbol(&bitC, &st[i % (size_t)x], src[i]);
+        if (++pk == 4 && i > 0) { BIT_flushBitsFast(&bitC); pk = 0; }
+    }
+    if (pk > 0) BIT_flushBitsFast(&bitC);   /* clean the container before the rounds */
+
+    /* i is now a multiple of x: the rest is the original aligned fast path,
+     * unchanged from before the any-length work -- fully-unrolled x-wide
+     * rounds (cursor == loop counter, round-local flush counter). */
     while (i > 0) {
         int pushed = 0;
         for (int k = x - 1; k >= 0; k--) {

--- a/src/pivco_fse.c
+++ b/src/pivco_fse.c
@@ -11,8 +11,8 @@
  * To experiment with a different cursor/unroll shape, override the two
  * macros below together (must be one of the decode_x{N}_y{M} functions
  * in fse_xy_codec.h, with X == N): e.g. -DPIVCO_FSE_XY_X=16
- * -DPIVCO_FSE_XY_DECODE=decode_x16_y2.  X must divide the bitmap byte
- * count for a node to use the wide path (else it falls back to stock). */
+ * -DPIVCO_FSE_XY_DECODE=decode_x16_y2.  Any bitmap byte length >= 64
+ * works on the wide path (below that it falls back to stock FSE). */
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #include "fse_xy_codec.h"
@@ -87,11 +87,19 @@ static void do_init(void)
 }
 
 /* Should this node use the wide-cursor path?  Same deterministic decision
- * on encode + decode (toggle + table-safety + size/alignment). */
+ * on encode + decode (toggle + table-safety + minimum size).
+ *
+ * The former `(nbytes % PIVCO_FSE_XY_X) == 0` term was a bench-era
+ * restriction with an outsized cost: bitmap lengths are ceil(K/8) with
+ * data-dependent K, so ~ (X-1)/X of all FSE'd bitmaps silently fell
+ * back to stock 2-state FSE (~1.6x slower) — and WHICH ones flipped
+ * with any size change, the main source of the FSE-heavy dists'
+ * "cursed" M4 variance (proba80 oscillated ±42% with period 64 in the
+ * block size: root bitmap = N/8 bytes, divisible by 8 iff N % 64 == 0).
+ * encode_x/the decode template now handle any length >= X. */
 static inline int use_wide(int table_id, size_t nbytes)
 {
-    return g_wide_on && g_wide_safe[table_id] &&
-           nbytes >= 64 && (nbytes % PIVCO_FSE_XY_X) == 0;
+    return g_wide_on && g_wide_safe[table_id] && nbytes >= 64;
 }
 
 void pivco_fse_init(void)

--- a/src/pivco_huffman_wire.h
+++ b/src/pivco_huffman_wire.h
@@ -6,7 +6,7 @@
  * which led to silent drift (scalar+NEON added the FSE marker byte in
  * 2026-05-13, x86+AVX-512 didn't — broke scalar↔SSE cross-decoding).
  *
- * Wire format (v0.5+):
+ * Wire format (v0.6+; the uint16 block_N header below is the v0.5 addition):
  *
  * Per-block header (once, at the very start of each encoded block):
  *   [block_N: uint16 LE, 2 bytes]                  symbol count N for this

--- a/test/test_edge_cases.c
+++ b/test/test_edge_cases.c
@@ -16,6 +16,9 @@
 
 #include "pivco_huffman.h"
 #include "pivcohuf_file.h"
+#ifdef PIVCO_HAS_FSE
+#include "pivco_fse.h"
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -324,6 +327,56 @@ static int test_fse_dispatch(void)
     return total_fail;
 }
 
+#ifdef PIVCO_HAS_FSE
+/* Direct FSE roundtrip at EVERY length 8..600: crosses the wide-path
+ * minimum (64) and every mod-X residue.  The former wide gate required
+ * nbytes % PIVCO_FSE_XY_X == 0; this sweep would have caught both that
+ * restriction's silent stock-FSE fallback and any encode_x/decode
+ * disagreement in the generalized any-length form (partial final
+ * round, cursor mapping, tight streams).  Three bit-density regimes
+ * cover low/mid/high table ids. */
+static int test_fse_length_sweep(void)
+{
+    printf("[fse_length_sweep] ");
+    pivco_fse_init();
+    uint64_t rng = 0x5eedf00d12345678ULL;
+    const double biases[] = { 0.65, 0.85, 0.97 };
+    int tested = 0, fell_back = 0;
+    for (int bi = 0; bi < 3; bi++) {
+        int t = pivco_fse_select_table(biases[bi]);
+        if (t < 1) FAIL("no table for bias %.2f", biases[bi]);
+        for (size_t n = 8; n <= 600; n++) {
+            uint8_t src[600], enc[800], dec[616];
+            for (size_t i = 0; i < n; i++) {
+                uint8_t b = 0;
+                for (int j = 0; j < 8; j++) {
+                    double u = (double)(xorshift64(&rng) >> 11) / 9007199254740992.0;
+                    b |= (uint8_t)((u > biases[bi]) << j);
+                }
+                src[i] = b;
+            }
+            size_t clen = 0;
+            pivco_fse_status_t rc = pivco_fse_compress(t, src, n,
+                                                       enc, sizeof(enc), &clen);
+            if (rc == PIVCO_FSE_FALLBACK) { fell_back++; continue; }
+            if (rc != PIVCO_FSE_OK) FAIL("compress n=%zu t=%d rc=%d", n, t, rc);
+            size_t olen = 0;
+            memset(dec, 0xCB, sizeof(dec));
+            rc = pivco_fse_decompress(t, enc, clen, dec, sizeof(dec), n, &olen);
+            if (rc != PIVCO_FSE_OK) FAIL("decompress n=%zu t=%d rc=%d", n, t, rc);
+            if (olen != n) FAIL("olen %zu != n %zu (t=%d)", olen, n, t);
+            if (memcmp(src, dec, n) != 0) {
+                size_t i; for (i = 0; i < n && src[i] == dec[i]; i++) ;
+                FAIL("mismatch n=%zu t=%d at byte %zu", n, t, i);
+            }
+            tested++;
+        }
+    }
+    printf("PASS (%d lengths, %d fallbacks)\n", tested, fell_back);
+    return 0;
+}
+#endif  /* PIVCO_HAS_FSE */
+
 /* ---------- entry point ---------- */
 
 int test_edge_cases_all(void)
@@ -341,5 +394,9 @@ int test_edge_cases_all(void)
     fails += test_adversarial();
     printf("\n--- FSE dispatch (v0.2 wire format) ---\n");
     fails += test_fse_dispatch();
+#ifdef PIVCO_HAS_FSE
+    printf("\n--- FSE length sweep ---\n");
+    fails += test_fse_length_sweep();
+#endif
     return fails;
 }


### PR DESCRIPTION
PHA-mode FSE was confusing my benchmarks, because changing the chunk size would change whether or not bitmap lengths were divisible by 8, which could toggle wide FSE decoding. Prior to this PR, 7/8ths of internal nodes run the non-wide, ~1.6x slower, decoder.

Apple M4 PHA speed and ratio changes (a little noisy):

```
┌─────────────────────┬───────────┬───────────┬─────────┐
│    distribution     │ decode Δ% │ encode Δ% │ size Δ% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ proba80             │    +16.4% │     +7.6% │  +0.55% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ csv_numeric         │    +19.1% │    +10.8% │  +0.08% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ bell_s10            │    +11.3% │     +4.1% │  +0.04% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ image_jpeg          │     +4.5% │     +3.5% │  +0.00% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ html_wiki           │     +4.8% │     +3.4% │  +0.03% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ chinese_text        │     +4.1% │     +9.3% │  +0.03% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ bell_s30            │     −0.4% │     +0.1% │  +0.00% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ bell_s80            │     −0.7% │     −0.1% │  +0.00% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ 21 others (mean)    │     +0.2% │     +0.2% │   0.00% │
├─────────────────────┼───────────┼───────────┼─────────┤
│ total size (all 29) │         — │         — │ +0.010% │
└─────────────────────┴───────────┴───────────┴─────────┘
```

(Increasing the length cutoff is an option, trading performance for ratio.)