### PR TITLE
ci: build + test + drop-in-object canary on 3 platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - os: macos-latest         # Apple Silicon NEON
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest        # x86-64: scalar + SSE4.1/AVX2 executed
+          - os: ubuntu-24.04-arm     # Linux NEON
+          - os: macos-latest         # Apple Silicon NEON
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build -j4
+      - name: Test
+        run: ./build/pivco_huffman_tests
+      - name: Drop-in object canary (the TurboBench link contract)
+        run: |
+          cmake --build build --target pivco_huffman_local -j4
+          echo 'int main(void){return 0;}' > canary.c
+          cc canary.c build/libpivco_huffman_local.o -lm -o canary

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -100,6 +100,13 @@ add_executable(pivco_bench_prim ${CMAKE_SOURCE_DIR}/bench/bench_prim.c)
 target_include_directories(pivco_bench_prim PRIVATE
     ${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src ${PHTD_DIR}/include)
 target_link_libraries(pivco_bench_prim pivco_huffman m)
+if(UNIX AND NOT APPLE)
+    # prim_variants keeps byte-exact asm replicas (c3roll asof pairs) that
+    # address their tables absolutely -- R_X86_64_32S, illegal in a PIE
+    # link.  The encoding IS what those variants preserve, so link this
+    # research binary non-PIE instead of rewriting them RIP-relative.
+    target_link_options(pivco_bench_prim PRIVATE -no-pie)
+endif()
 
 # Optional Oodle reference comparison, consumed here by pivco_fair_bench and --
 # via the inherited OODLE_* vars -- by pivco_fse_xy_micro under extras/bench/.


### PR DESCRIPTION
Minimal starting CI: Release build + test suite on ubuntu x86-64, ubuntu ARM (Linux NEON), and Apple Silicon macOS, plus a canary that builds `libpivco_huffman_local.o` and links it into a trivial binary with `-lm` — gating the TurboBench drop-in contract (the `log2`/libm breakage class from the #24 merge, caught downstream by powturbo).

`-Werror` deliberately omitted for now: existing format-string and indentation warnings on Linux toolchains need their own cleanup pass first. Debug/ASan jobs are easy follow-ups once this is proven.

This PR is itself the test of the `pull_request` trigger; merging exercises the `push` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
